### PR TITLE
Corrected dependancy on Clean-URLs in Islandora using drupal 7

### DIFF
--- a/includes/ingest.form.inc
+++ b/includes/ingest.form.inc
@@ -15,6 +15,7 @@
  *   The ingest form.
  */
 function islandora_basic_collection_ingest_action(FedoraObject $object) {
+  dsm('configuration islandora_basic_collection_ingest_action' . '</b>',$configuration);
   if (($configuration = islandora_basic_collection_get_ingest_configuration($object)) !== FALSE) {
     module_load_include('inc', 'islandora', 'includes/ingest.form');
     return drupal_get_form('islandora_ingest_form', $configuration);

--- a/includes/ingest.form.inc
+++ b/includes/ingest.form.inc
@@ -15,7 +15,6 @@
  *   The ingest form.
  */
 function islandora_basic_collection_ingest_action(FedoraObject $object) {
-  dsm('configuration islandora_basic_collection_ingest_action' . '</b>',$configuration);
   if (($configuration = islandora_basic_collection_get_ingest_configuration($object)) !== FALSE) {
     module_load_include('inc', 'islandora', 'includes/ingest.form');
     return drupal_get_form('islandora_ingest_form', $configuration);

--- a/includes/manage_collection.inc
+++ b/includes/manage_collection.inc
@@ -243,7 +243,7 @@ function islandora_basic_collection_policy_management_form(array $form, array &$
     $content_model_in_policy = isset($policy_content_models[$pid]);
     $namespace = $content_model_in_policy ? $policy_content_models[$pid]['namespace'] : $default_namespace;
     $namespace_element = islandora_basic_collection_get_namespace_form_element($namespace);
-    unset($namespace_element['#title'],$namespace_element['#description']);
+    unset($namespace_element['#title'], $namespace_element['#description']);
     $rows[$pid] = array(
       'selected' => array(
         '#type' => 'checkbox',

--- a/islandora_basic_collection.install
+++ b/islandora_basic_collection.install
@@ -24,7 +24,6 @@ function islandora_basic_collection_uninstall() {
   $variables = array(
     'islandora_basic_collection_page_size',
     'islandora_basic_collection_disable_collection_policy_delete',
-    'islandora_basic_collection_default_view'
-  );
+    'islandora_basic_collection_default_view');
   array_walk($variables, 'variable_del');
 }

--- a/islandora_basic_collection.install
+++ b/islandora_basic_collection.install
@@ -24,6 +24,7 @@ function islandora_basic_collection_uninstall() {
   $variables = array(
     'islandora_basic_collection_page_size',
     'islandora_basic_collection_disable_collection_policy_delete',
-    'islandora_basic_collection_default_view');
+    'islandora_basic_collection_default_view',
+  );
   array_walk($variables, 'variable_del');
 }

--- a/islandora_basic_collection.module
+++ b/islandora_basic_collection.module
@@ -238,10 +238,7 @@ function islandora_basic_collection_islandora_overview_object(FedoraObject $obje
     $pids = islandora_basic_collection_get_parent_pids($object);
     $rows = array_map($map_to_row, $pids);
     return array(
-      'collection' => theme('table', array(
-          'header' => array(t('Parent Collections')),
-            'rows' => $rows,
-            'empty' => t('No parent collections'))),
+      'collection' => theme('table', array('header' => array(t('Parent Collections')), 'rows' => $rows, 'empty' => t('No parent collections'))),
     );
   }
 }

--- a/islandora_basic_collection.module
+++ b/islandora_basic_collection.module
@@ -59,7 +59,7 @@ function islandora_basic_collection_menu_alter(&$items) {
     MIGRATE_COLLECTION_MEMBERS,
   );
   $new_access_arguments = array_merge($current_access_arguments, $new_access_arguments);
-  $items['islandora/object/%islandora_object/manage']['access arguments'] = array($new_access_arguments,2);
+  $items['islandora/object/%islandora_object/manage']['access arguments'] = array($new_access_arguments, 2);
 }
 
 /**

--- a/islandora_basic_collection.module
+++ b/islandora_basic_collection.module
@@ -238,7 +238,10 @@ function islandora_basic_collection_islandora_overview_object(FedoraObject $obje
     $pids = islandora_basic_collection_get_parent_pids($object);
     $rows = array_map($map_to_row, $pids);
     return array(
-      'collection' => theme('table', array('header' => array(t('Parent Collections')), 'rows' => $rows, 'empty' => t('No parent collections'))),
+      'collection' => theme('table', array(
+          'header' => array(t('Parent Collections')),
+            'rows' => $rows,
+            'empty' => t('No parent collections'))),
     );
   }
 }

--- a/tests/islandora_basic_collection_manage_permissions.test
+++ b/tests/islandora_basic_collection_manage_permissions.test
@@ -40,10 +40,7 @@ class IslandoraBasicCollectionPermissionsTestCase extends IslandoraWebTestCase {
     $this->assertNoLink('Manage', 'Manage tab is not on current page.');
 
     // Test permission FEDORA_VIEW_OBJECTS, CREATE_CHILD_COLLECTION.
-    $user = $this->drupalCreateUser(array(
-        FEDORA_VIEW_OBJECTS,
-        FEDORA_INGEST,
-        CREATE_CHILD_COLLECTION));
+    $user = $this->drupalCreateUser(array(FEDORA_VIEW_OBJECTS, FEDORA_INGEST, CREATE_CHILD_COLLECTION));
     $this->drupalLogin($user);
     $this->clickLink(t('Islandora Repository'));
     $this->assertLink('Manage', 0, 'Manage tab is on current page.');

--- a/tests/islandora_basic_collection_manage_permissions.test
+++ b/tests/islandora_basic_collection_manage_permissions.test
@@ -40,7 +40,10 @@ class IslandoraBasicCollectionPermissionsTestCase extends IslandoraWebTestCase {
     $this->assertNoLink('Manage', 'Manage tab is not on current page.');
 
     // Test permission FEDORA_VIEW_OBJECTS, CREATE_CHILD_COLLECTION.
-    $user = $this->drupalCreateUser(array(FEDORA_VIEW_OBJECTS, FEDORA_INGEST, CREATE_CHILD_COLLECTION));
+    $user = $this->drupalCreateUser(array(
+        FEDORA_VIEW_OBJECTS,
+        FEDORA_INGEST,
+        CREATE_CHILD_COLLECTION));
     $this->drupalLogin($user);
     $this->clickLink(t('Islandora Repository'));
     $this->assertLink('Manage', 0, 'Manage tab is on current page.');

--- a/theme/islandora-basic-collection-wrapper.tpl.php
+++ b/theme/islandora-basic-collection-wrapper.tpl.php
@@ -16,5 +16,6 @@
     <?php print $collection_pager; ?>
     <?php print $collection_content; ?>
     <?php print $collection_pager; ?>
+
   </div>
 </div>

--- a/theme/theme.inc
+++ b/theme/theme.inc
@@ -32,7 +32,7 @@ function islandora_basic_collection_preprocess_islandora_basic_collection_wrappe
     $list_link = array(
       'title' => 'List view',
       'href' => '/islandora/object/' . $islandora_object->id,
-      'attributes' => array('class' => 'islandora-view-list'), 
+      'attributes' => array('class' => 'islandora-view-list'),
       'query' => $query_params,
     );
     unset($query_params['display']);
@@ -50,7 +50,7 @@ function islandora_basic_collection_preprocess_islandora_basic_collection_wrappe
     $list_link = array(
       'title' => 'List view',
       'href' => '/islandora/object/' . $islandora_object->id,
-      'attributes' => array('class' => array('islandora-view-list','active')),
+      'attributes' => array('class' => array('islandora-view-list', 'active')),
       'query' => $query_params,
     );
     unset($query_params['display']);
@@ -96,29 +96,25 @@ function islandora_basic_collection_preprocess_islandora_basic_collection(&$vari
     $variables['theme_hook_suggestions'][] = 'islandora_basic_collection__' . str_replace(':', '_', $islandora_object->id);
   }
   if (isset($islandora_object['OBJ'])) {
-  	$full_size_url = url("/islandora/object/{$islandora_object->id}/datastram/OBJ/view");
-  	$params = array(
-  		'title' => $islandora_object->label,
-  		'path' => $full_size_url	
-  			);
-  	$variables['islandora_full_img'] = theme('image',$params);
-  	
+    $full_size_url = url("/islandora/object/{$islandora_object->id}/datastram/OBJ/view");
+    $params = array(
+      'title' => $islandora_object->label,
+      'path' => $full_size_url);
+    $variables['islandora_full_img'] = theme('image', $params);
   }
   if (isset($islandora_object['TN'])) {
-  	$full_size_url = url("/islandora/objects/{$islandora_object->id}/datastream/TN/view");
-  	$params = array(
-  		'title' => $islandora_object->label,
-  		'path' => $full_size_url	
-  			);
-  	$variables['islandora_thumbnail_img'] = theme('image', $params);
+    $full_size_url = url("/islandora/objects/{$islandora_object->id}/datastream/TN/view");
+    $params = array(
+      'title' => $islandora_object->label,
+      'path' => $full_size_url);
+    $variables['islandora_thumbnail_img'] = theme('image', $params);
   }
   if (isset($islandora_object['MEDIUM_SIZE'])) {
-  	$full_size_url = url("/islandora/object/{$islandora_object->id}/datastream/MEDIUM_SIZE/view");
-  	$params = array(
-  		'title' => $islandora_object->label,
-  		'path' => $full_size_url	
-  			);
-  	$variables['islandora_medium_img'] = theme('params',$params);
+    $full_size_url = url("/islandora/object/{$islandora_object->id}/datastream/MEDIUM_SIZE/view");
+    $params = array(
+      'title' => $islandora_object->label,
+      'path' => $full_size_url);
+    $variables['islandora_medium_img'] = theme('params', $params);
   }
 
   $associated_objects_array = array();
@@ -142,36 +138,22 @@ function islandora_basic_collection_preprocess_islandora_basic_collection(&$vari
       drupal_set_message(t('Error retrieving object %s %t', array('%s' => $islandora_object->id, '%t' => $e->getMessage())), 'error', FALSE);
     }
     $object_url = 'islandora/object/' . $pid;
-    
-    
-   // $params = array(
-    //	'title' => $results[$i]['title']['value'],
-    	//'path' => url($object_url . $object_url . '/datastrea/TM/view')
-    	//	);
-   // $thumbnail_img = theme('params',$params);
-    $imgSource = url($object_url . '/datastream/TN/view');
-    $thumbnail_img = '<img src="' . $imgSource . '/>';
-    //$thumbnail_img = '<img src="' . $base_path . $object_url . '/datastream/TN/view"' . '/>';
-    
+
+    $img_source = url($object_url . '/datastream/TN/view');
+    $thumbnail_img = '<img src="' . $img_source . '/>';
+
     $title = $results[$i]['title']['value'];
     $associated_objects_array[$pid]['pid'] = $pid;
     $associated_objects_array[$pid]['path'] = $object_url;
     $associated_objects_array[$pid]['title'] = $title;
     $associated_objects_array[$pid]['class'] = drupal_strtolower(preg_replace('/[^A-Za-z0-9]/', '-', $pid));
     if (isset($fc_object['TN'])) {
-    	//$thumbnail_img = theme('params',$params);
-    	$imgSource = url($object_url . '/datastream/TN/view');
-      $thumbnail_img = '<img src="' . $imgSource . '"/>';
+      $img_source = url($object_url . '/datastream/TN/view');
+      $thumbnail_img = '<img src="' . $img_source . '"/>';
     }
     else {
-      //$image_path = drupal_get_path('module', 'islandora');
-      //$params = array(
-      		//'title' => $results[$i]['title']['value'],
-      		//'path' => url($image_path . '/images/folder.png')
-      //);
-      //$thumbnail_img = theme('params',$params);
-      $imgSource = url($image_path . '/images/folder.png');
-      $thumbnail_img = '<img src="' . $imgSource . '"/>';
+      $img_source = url($image_path . '/images/folder.png');
+      $thumbnail_img = '<img src="' . $img_source . '"/>';
     }
     $associated_objects_array[$pid]['thumbnail'] = $thumbnail_img;
     $associated_objects_array[$pid]['title_link'] = l($title, $object_url, array('html' => TRUE, 'attributes' => array('title' => $title)));

--- a/theme/theme.inc
+++ b/theme/theme.inc
@@ -31,17 +31,15 @@ function islandora_basic_collection_preprocess_islandora_basic_collection_wrappe
     $query_params['display'] = 'list';
     $list_link = array(
       'title' => 'List view',
-      'href' => $base_url . '/islandora/object/' . $islandora_object->id,
-      'attributes' => array(
-        'class' => 'islandora-view-list',
-      ),
+      'href' => '/islandora/object/' . $islandora_object->id,
+      'attributes' => array('class' => 'islandora-view-list'), 
       'query' => $query_params,
     );
     unset($query_params['display']);
     $query_params['display'] = 'grid';
     $grid_link = array(
       'title' => 'Grid view',
-      'href' => $base_url . '/islandora/object/' . $islandora_object->id,
+      'href' => '/islandora/object/' . $islandora_object->id,
       'attributes' => array('class' => array('islandora-view-grid', 'active')),
       'query' => $query_params,
     );
@@ -51,15 +49,15 @@ function islandora_basic_collection_preprocess_islandora_basic_collection_wrappe
     $query_params['display'] = 'list';
     $list_link = array(
       'title' => 'List view',
-      'href' => $base_url . '/islandora/object/' . $islandora_object->id,
-      'attributes' => array('class' => array('islandora-view-list', 'active')),
+      'href' => '/islandora/object/' . $islandora_object->id,
+      'attributes' => array('class' => array('islandora-view-list','active')),
       'query' => $query_params,
     );
     unset($query_params['display']);
     $query_params['display'] = 'grid';
     $grid_link = array(
       'title' => 'Grid view',
-      'href' => $base_url . '/islandora/object/' . $islandora_object->id,
+      'href' => '/islandora/object/' . $islandora_object->id,
       'attributes' => array('class' => 'islandora-view-grid'),
       'query' => $query_params,
     );
@@ -98,16 +96,29 @@ function islandora_basic_collection_preprocess_islandora_basic_collection(&$vari
     $variables['theme_hook_suggestions'][] = 'islandora_basic_collection__' . str_replace(':', '_', $islandora_object->id);
   }
   if (isset($islandora_object['OBJ'])) {
-    $full_size_url = $base_url . '/islandora/object/' . $islandora_object->id . '/datastream/OBJ/view';
-    $variables['islandora_full_img'] = '<img src="' . $full_size_url . '"/>';
+  	$full_size_url = url("/islandora/object/{$islandora_object->id}/datastram/OBJ/view");
+  	$params = array(
+  		'title' => $islandora_object->label,
+  		'path' => $full_size_url	
+  			);
+  	$variables['islandora_full_img'] = theme('image',$params);
+  	
   }
   if (isset($islandora_object['TN'])) {
-    $thumbnail_size_url = $base_url . '/islandora/object/' . $islandora_object->id . '/datastream/TN/view';
-    $variables['islandora_thumbnail_img'] = '<img src="' . $thumbnail_size_url . '"/>';
+  	$full_size_url = url("/islandora/objects/{$islandora_object->id}/datastream/TN/view");
+  	$params = array(
+  		'title' => $islandora_object->label,
+  		'path' => $full_size_url	
+  			);
+  	$variables['islandora_thumbnail_img'] = theme('image', $params);
   }
   if (isset($islandora_object['MEDIUM_SIZE'])) {
-    $medium_size_url = $base_url . '/islandora/object/' . $islandora_object->id . '/datastream/MEDIUM_SIZE/view';
-    $variables['islandora_medium_img'] = '<img src="' . $medium_size_url . '"/>';
+  	$full_size_url = url("/islandora/object/{$islandora_object->id}/datastream/MEDIUM_SIZE/view");
+  	$params = array(
+  		'title' => $islandora_object->label,
+  		'path' => $full_size_url	
+  			);
+  	$variables['islandora_medium_img'] = theme('params',$params);
   }
 
   $associated_objects_array = array();
@@ -131,18 +142,36 @@ function islandora_basic_collection_preprocess_islandora_basic_collection(&$vari
       drupal_set_message(t('Error retrieving object %s %t', array('%s' => $islandora_object->id, '%t' => $e->getMessage())), 'error', FALSE);
     }
     $object_url = 'islandora/object/' . $pid;
-    $thumbnail_img = '<img src="' . $base_path . $object_url . '/datastream/TN/view"' . '/>';
+    
+    
+   // $params = array(
+    //	'title' => $results[$i]['title']['value'],
+    	//'path' => url($object_url . $object_url . '/datastrea/TM/view')
+    	//	);
+   // $thumbnail_img = theme('params',$params);
+    $imgSource = url($object_url . '/datastream/TN/view');
+    $thumbnail_img = '<img src="' . $imgSource . '/>';
+    //$thumbnail_img = '<img src="' . $base_path . $object_url . '/datastream/TN/view"' . '/>';
+    
     $title = $results[$i]['title']['value'];
     $associated_objects_array[$pid]['pid'] = $pid;
     $associated_objects_array[$pid]['path'] = $object_url;
     $associated_objects_array[$pid]['title'] = $title;
     $associated_objects_array[$pid]['class'] = drupal_strtolower(preg_replace('/[^A-Za-z0-9]/', '-', $pid));
     if (isset($fc_object['TN'])) {
-      $thumbnail_img = '<img src="' . $base_path . $object_url . '/datastream/TN/view"' . '/>';
+    	//$thumbnail_img = theme('params',$params);
+    	$imgSource = url($object_url . '/datastream/TN/view');
+      $thumbnail_img = '<img src="' . $imgSource . '"/>';
     }
     else {
-      $image_path = drupal_get_path('module', 'islandora');
-      $thumbnail_img = '<img src="' . $base_path . $image_path . '/images/folder.png"/>';
+      //$image_path = drupal_get_path('module', 'islandora');
+      //$params = array(
+      		//'title' => $results[$i]['title']['value'],
+      		//'path' => url($image_path . '/images/folder.png')
+      //);
+      //$thumbnail_img = theme('params',$params);
+      $imgSource = url($image_path . '/images/folder.png');
+      $thumbnail_img = '<img src="' . $imgSource . '"/>';
     }
     $associated_objects_array[$pid]['thumbnail'] = $thumbnail_img;
     $associated_objects_array[$pid]['title_link'] = l($title, $object_url, array('html' => TRUE, 'attributes' => array('title' => $title)));


### PR DESCRIPTION
Islandora 7 Broken with Clean URLs turned off - ISLANDORA-700:
Corrected dependancy on Clean URL's by using the url() and theme() function when constructing url's.  Ran the code thru PHPCodeSniffer and the Coder module. Local testing did not reveal any additional broken links.
