### PR TITLE
fixed image_path reference broken in ef1e4d6f34da4c0f7031b144757cdc99396...

### DIFF
--- a/theme/theme.inc
+++ b/theme/theme.inc
@@ -152,6 +152,7 @@ function islandora_basic_collection_preprocess_islandora_basic_collection(&$vari
       $thumbnail_img = '<img src="' . $img_source . '"/>';
     }
     else {
+      $image_path = drupal_get_path('module', 'islandora');
       $img_source = url($image_path . '/images/folder.png');
       $thumbnail_img = '<img src="' . $img_source . '"/>';
     }


### PR DESCRIPTION
...431d7

Looks like $base_url was getting cleaned up but $image_path was broken when the point where it was defined was commented out.  There may be a cleaner approach that that commit was going for, but I just added the $image_path = drupal_get_path('module', 'islandora'); back.

This resolves the error message we were getting that $image_path isn't defined.
