### PR TITLE
Use count query to perform paging.

### DIFF
--- a/includes/batch.inc
+++ b/includes/batch.inc
@@ -67,24 +67,45 @@ function islandora_basic_collection_batch_finished($success, $results, $operatio
  *   The batch definition.
  */
 function islandora_basic_collection_delete_children_batch(AbstractObject $collection, $children = NULL) {
-  $children = is_array($children) ? $children : islandora_basic_collection_get_child_pids($collection);
-  $parameters = array($collection, $children);
-  $delete_child_operation = array('islandora_basic_collection_delete_children_batch_operation', $parameters);
-  $child_count = count($children);
-  $message_parameters = array('@collection' => $collection->label);
-  return array(
-    'operations' => array($delete_child_operation),
+  $batch = array(
     'finished' => 'islandora_basic_collection_batch_finished',
-    'title' => format_plural($child_count,
-      'Deleting 1 child from @collection ...',
-      'Deleting @count children from @collection ...', $message_parameters),
-    'init_message' => format_plural($child_count,
-      'Preparing to delete 1 child from @collection ...',
-      'Preparing to delete @count children from @collection ...', $message_parameters),
-    'progress_message' => t('Time elapsed: @elapsed <br/>Estimated time remaning @estimate.'),
+    'progress_message' => t('Time elapsed: @elapsed <br/>Estimated time remaining @estimate.'),
     'error_message' => t('An error has occurred.'),
     'file' => drupal_get_path('module', 'islandora_basic_collection') . '/includes/batch.inc',
   );
+
+  $message_parameters = array('@collection' => $collection->label);
+  if (is_array($children)) {
+    $child_count = count($children);
+    $batch += array(
+      'operations' => array(
+        array(
+          'islandora_basic_collection_delete_children_batch_operation',
+          array($collection, $children),
+        ),
+      ),
+      'title' => format_plural($child_count,
+        'Deleting 1 child from @collection ...',
+        'Deleting @count children from @collection ...', $message_parameters),
+      'init_message' => format_plural($child_count,
+        'Preparing to delete 1 child from @collection ...',
+        'Preparing to delete @count children from @collection ...', $message_parameters),
+    );
+  }
+  else {
+    $batch += array(
+      'operations' => array(
+        array(
+          'islandora_basic_collection_delete_all_children_batch_operation',
+          array($collection),
+        ),
+      ),
+      'title' => t('Deleting all children of @collection.', $message_parameters),
+      'init_message' => t('Preparing to delete all children of @collection.', $message_parameters),
+    );
+  }
+
+  return $batch;
 }
 
 /**
@@ -115,6 +136,71 @@ function islandora_basic_collection_delete_children_batch_operation(AbstractObje
   }
   if (islandora_basic_collection_end_operation($context)) {
     drupal_set_message(format_plural(count($children),
+      'Deleted 1 child from <a href="@collection-url">@collection</a>.',
+      'Deleted @count children from <a href="@collection-url">@collection</a>.',
+      array(
+        '@collection' => $collection->label,
+        '@collection-url' => url("islandora/object/{$collection->id}"),
+      )
+    ));
+  }
+}
+
+/**
+ * Batch operation to delete ALL children from the given collection.
+ *
+ * @param AbstractObject $collection
+ *   The collection object to purge the children from.
+ * @param array $context
+ *   The batch context.
+ */
+function islandora_basic_collection_delete_all_children_batch_operation(AbstractObject $collection, &$context) {
+  $query_info = islandora_basic_collection_get_query_info(array(
+    'object' => $collection,
+  ));
+
+  if (!isset($context['sandbox']['total_count'])) {
+    $context['sandbox']['total_count'] = $collection->repository->ri->countQuery($query_info['query'], $query_info['type']);
+    if ($context['sandbox']['total_count'] === 0) {
+      drupal_set_message(t('No objects to delete in @collection.', array(
+        '@collection' => $collection->label,
+      )));
+      $context['finished'] = 1;
+      return;
+    }
+    $context['sandbox']['current'] = 0.0;
+  }
+
+  $results = islandora_basic_collection_get_member_objects($collection, 0, 10);
+  if ($results) {
+    list($count, $members) = $results;
+    foreach ($members as $result) {
+      $child = $result['object']['value'];
+      if ($child && $child = islandora_object_load($child)) {
+        $other_parents = islandora_basic_collection_get_other_parents($child, $collection);
+        // If only one parent, delete the object.
+        if (empty($other_parents)) {
+          islandora_delete_object($child);
+        }
+        else {
+          // If more than one parent, only remove parent relationship.
+          islandora_basic_collection_remove_from_collection($child, $collection);
+        }
+      }
+    }
+
+    $context['sandbox']['current'] += $count;
+
+    if ($count === 0) {
+      $context['finished'] = 1;
+    }
+    else {
+      $context['finished'] = $context['sandbox']['current'] / $context['sandbox']['total_count'];
+    }
+  }
+
+  if (!$results || $context['finished'] == 1) {
+    drupal_set_message(format_plural($context['sandbox']['current'],
       'Deleted 1 child from <a href="@collection-url">@collection</a>.',
       'Deleted @count children from <a href="@collection-url">@collection</a>.',
       array(

--- a/includes/utilities.inc
+++ b/includes/utilities.inc
@@ -22,7 +22,10 @@
 function islandora_basic_collection_get_content_models_as_form_options(array $content_models) {
   $map_content_models_to_options = function($o) {
     $label = isset($o['label']) ? $o['label'] : $o['name'];
-    return "{$o['pid']} ~ {$label}";
+    return format_string('!pid ~ !label', array(
+      '!pid' => $o['pid'],
+      '!label' => $label,
+    ));
   };
   return array_map($map_content_models_to_options, $content_models);
 }
@@ -91,10 +94,10 @@ function islandora_basic_collection_get_namespace_form_element($default_value) {
 function islandora_basic_collection_get_children_select_table_form_element(AbstractObject $object, array $pager_options) {
   // Assumes all results are returned although the function description
   // states otherwise.
-  $results = islandora_basic_collection_get_objects($object);
   $limit = 10;
-  $page = pager_default_initialize(count($results), $limit, $pager_options['element']);
-  $results = array_slice($results, $page * $limit, $limit);
+  $page = pager_find_page($pager_options['element']);
+  list($count, $results) = islandora_basic_collection_get_member_objects($object, $page, $limit);
+  $page = pager_default_initialize($count, $limit, $pager_options['element']);
   $rows = array();
   foreach ($results as $result) {
     $pid = $result['object']['value'];
@@ -133,16 +136,26 @@ function islandora_basic_collection_get_children_select_table_form_element(Abstr
  *   The list of child PIDs.
  */
 function islandora_basic_collection_get_child_pids(AbstractObject $object, $type = NULL) {
-  $results = islandora_basic_collection_get_objects($object);
+  module_load_include('inc', 'islandora', 'includes/utilities');
+  $message = islandora_deprecated('7.x-1.2', 'Code should be made to page over all objects to avoid potential memory issues with large collections.');
+  trigger_error(filter_xss($message), E_USER_DEPRECATED);
+
+  $params = array(
+    'object' => $object,
+    'page_size' => -1,
+  );
+
   if (isset($type)) {
-    $filter_type = function($o) use($type) {
-      return $o['content']['value'] == $type;
-    };
-    $results = array_filter($results, $filter_type);
+    $params['model'] = "<info:fedora/$type>";
   }
+
   $map_results = function($o) {
     return $o['object']['value'];
   };
+
+  $query_info = islandora_basic_collection_get_query_info($params);
+  $results = $object->repository->ri->query($query_info['query'], $query_info['type']);
+
   return array_map($map_results, $results);
 }
 

--- a/islandora_basic_collection.api.php
+++ b/islandora_basic_collection.api.php
@@ -1,0 +1,75 @@
+<?php
+
+/**
+ * @file
+ * Hook documentation
+ */
+
+/**
+ * Hook to get a number of Sparql statements, to build the collection query.
+ *
+ * @return array|string
+ *   Either an array containing multiple or a string containing a single
+ *   Sparql statement. This is to build up the tuples available to be filtered.
+ *   There are a number of placeholders which may be included for replacement:
+ *   - "!pid": The identifier of the collection object, as
+ *     "namespace:local-name" (no "info:fedora/" bit).
+ *   - "!model": A string representing a URI. Defaults to "?model", but could
+ *     be provided as "<info:fedora/cmodel:pid>" if the type of object to query
+ *     should be filtered.
+ */
+function hook_islandora_basic_collection_get_query_statements() {
+  return <<<EOQ
+  ?object ?collection_predicate <info:fedora/!pid> ;
+          <fedora-model:label> ?title ;
+          <fedora-model:hasModel> !model ;
+          <fedora-model:state> <fedora-model:Active>
+EOQ;
+}
+
+/**
+ * Hook to get a number of Sparql filters, to build the collection query.
+ *
+ * @return array|string
+ *   Either an array containing multiple or a string containing a single
+ *   Sparql filter. This is to reduce the tuples to return, as selected with
+ *   hook_islandora_basic_collection_get_query_statements(). There are a number
+ *   of placeholders which may be included for replacement:
+ *   - "!pid": The identifier of the collection object, as
+ *     "namespace:local-name" (no "info:fedora/" bit).
+ *   - "!model": A string representing a URI. Defaults to "?model", but could
+ *     be provided as "<info:fedora/cmodel:pid>" if the type of object to query
+ *     should be filtered.
+ */
+function hook_islandora_basic_collection_get_query_filters() {
+  return 'sameTerm(?collection_predicate, <fedora-rels-ext:isMemberOfCollection>) || sameTerm(?collection_predicate, <fedora-rels-ext:isMemberOf>)';
+}
+
+/**
+ * Allow altering of the built query.
+ *
+ * Note that this is only called after the query is fully build, so changes to
+ * those parameters associated with placeholders (model, vars, pid, etc) will
+ * not have any effect on the outcome.
+ *
+ * @param array $params
+ *   An associative array containing associated information about the query,
+ *   including everything passed in the the
+ *   islanora_basic_collection_get_query_info() as parameters, with a minimum
+ *   of:
+ *   - object: The AbstractObject for representing the collection we for which
+ *     we are querying.
+ *   - page_size: An integer representing the number of items per page.
+ *   - page_number: An integer representing which page we are on.
+ *   - vars: A string listing the variables which will comprise the types
+ *     returned.
+ *   - order_by: A string indicating which variable by which to sort. Defaults
+ *     to "?title". May be set to FALSE to avoid sorting.
+ *   - model: A string representing a URI. Defaults to "?model", but could
+ *     be provided as "<info:fedora/cmodel:pid>" if the type of object to query
+ *     should be filtered.
+ *   - query: The fully built query.
+ *   - type: The type of the query ('sparql' by default).
+ *   - pid: The identifier associated with 'object'.
+ */
+function hook_islandora_basic_collection_query_alter(array &$params) {}

--- a/islandora_basic_collection.module
+++ b/islandora_basic_collection.module
@@ -193,22 +193,48 @@ function islandora_basic_collection_islandora_collectionCModel_islandora_view_ob
  */
 function islandora_basic_collection_islandora_collectionCModel_islandora_overview_object(AbstractObject $object) {
   $rows = array();
-  $members = islandora_basic_collection_get_objects($object);
-  foreach ($members as $member) {
-    $content_model = islandora_object_load($member['content']['value']);
-    if (isset($rows[$content_model->id])) {
-      $rows[$content_model->id][1]++;
+  $model_query = islandora_basic_collection_get_query_info(array(
+    'object' => $object,
+    'page_size' => -1,
+    'page_number' => 0,
+    'vars' => '?model',
+    'order_by' => FALSE,
+  ));
+  $models = (array) $object->repository->ri->query($model_query['query'], $model_query['type']);
+  $ignore_models = array(
+    'fedora-system:FedoraObject-3.0',
+  );
+  foreach ($models as $model) {
+    $model_pid = $model['model']['value'];
+    if (in_array($model_pid, $ignore_models)) {
+      continue;
     }
-    else {
-      $link = l($content_model->label, "islandora/object/{$content_model->id}");
-      $rows[$content_model->id] = array($link, 1);
-    }
+    $model_count_query = islandora_basic_collection_get_query_info(array(
+      'object' => $object,
+      'page_size' => -1,
+      'page_number' => 0,
+      'order_by' => FALSE,
+      'model' => "<info:fedora/$model_pid>",
+    ));
+    $model_object = islandora_object_load($model_pid);
+    $rows[$model_pid] = array(
+      ($model_object ?
+        l($model_object->label, "islandora/object/{$model_object->id}") :
+        $model_pid),
+      $object->repository->ri->countQuery($model_count_query['query'], $model_count_query['type']),
+    );
   }
+
+  list($total_count, $all_results) = islandora_basic_collection_get_member_objects($object, 0, 0);
+
   $content = array(
-    'total' => array('#markup' => t('Total members: %total', array('%total' => count($members)))),
+    'total' => array('#markup' => t('Total members: %total', array('%total' => $total_count))),
     'table' => array(
       '#theme' => 'table',
-      '#header' => array('type' => array('data' => t('Type')), 'count' => array('data' => t('Count'))),
+      '#header' => array(
+        'type' => array('data' => t('Type')),
+        'count' => array('data' => t('Count')),
+      ),
       '#rows' => $rows,
       '#empty' => t('Collection is empty.')),
   );
@@ -238,6 +264,101 @@ function islandora_basic_collection_islandora_overview_object(AbstractObject $ob
 }
 
 /**
+ * Get the query to get child objects.
+ *
+ * @param array $params
+ *   An array containing all the parameters, at least:
+ *   - object: An AbstractObject we're querying for.
+ *   - page_size: The size of the page/number of results to return.
+ *   - page_number: An integer representing the offset as a multiple of
+ *     page_size.
+ *   - vars: A string containing the list of variables to select. Defaults to
+ *     "?object ?title".
+ *   - order_by: A string indicating which variable by which to sort. Defaults
+ *     to "?title". May be set to FALSE to avoid sorting.
+ *
+ * @return array
+ *   An array containing a number of keys used to describe the query,
+ *   including all the values from $params (which haven't been unset in the
+ *   alter), in addition to:
+ *   - query: The actual query string.
+ *   - type: A string containing the type of query, likely one of:
+ *     - itql; or,
+ *     - sparql.
+ *   - pid: The pid of the collection being queried.
+ */
+function islandora_basic_collection_get_query_info(array $params) {
+  // Add in defaults.
+  $params += array(
+    'page_number' => 0,
+    'page_size' => 10,
+    'vars' => '?object ?title',
+    'order_by' => '?title',
+    'model' => '?model',
+  );
+
+  $object = $params['object'];
+
+  $query = <<<EOQ
+SELECT !vars
+FROM <#ri>
+WHERE {
+  !statements .
+  !filters
+}
+EOQ;
+
+  $filters = array();
+  foreach (module_invoke_all('islandora_basic_collection_get_query_filters') as $filter) {
+    $filters[] = "FILTER($filter)";
+  }
+  $query = format_string($query, array(
+    '!statements' => implode(' . ', module_invoke_all('islandora_basic_collection_get_query_statements')),
+    '!filters' => implode(' ', $filters),
+  ));
+
+  $query = format_string($query, array(
+    '!vars' => $params['vars'],
+    '!pid' => $object->id,
+    '!model' => $params['model'],
+  ));
+
+  if ($params['order_by']) {
+    $query .= <<<EOQO
+ORDER BY {$params['order_by']}
+EOQO;
+  }
+
+  $query_array = $params + array(
+    'query' => $query,
+    'type' => 'sparql',
+    'pid' => $object->id,
+  );
+  drupal_alter('islandora_basic_collection_query', $query_array);
+
+  return $query_array;
+}
+
+/**
+ * Implements hook_islandora_basic_collection_get_query_statements().
+ */
+function islandora_basic_collection_islandora_basic_collection_get_query_statements() {
+  return <<<EOQ
+  ?object ?collection_predicate <info:fedora/!pid> ;
+          <fedora-model:label> ?title ;
+          <fedora-model:hasModel> !model ;
+          <fedora-model:state> <fedora-model:Active>
+EOQ;
+}
+
+/**
+ * Implements hook_islandora_basic_collection_get_query_filters().
+ */
+function islandora_basic_collection_islandora_basic_collection_get_query_filters() {
+  return 'sameTerm(?collection_predicate, <fedora-rels-ext:isMemberOfCollection>) || sameTerm(?collection_predicate, <fedora-rels-ext:isMemberOf>)';
+}
+
+/**
  * Get objects associated with this object.
  *
  * Currently, we are only concerned with the with isMemberOf and
@@ -250,46 +371,91 @@ function islandora_basic_collection_islandora_overview_object(AbstractObject $ob
  * @param int $page_size
  *   The number of results per page page from the query for members.
  *
- * @return array
- *   Query results.
+ * @return array|bool
+ *   An array containing two values:
+ *   - An integer representing the total number of tuples which can be
+ *     selected with the given parameters.
+ *   - The tuples in the slice according to $page_number and $page_size.
+ *   or boolean FALSE if the query fails.
  */
-function islandora_basic_collection_get_objects(AbstractObject $object, $page_number = 1, $page_size = 5) {
-  module_load_include('inc', 'islandora', 'includes/utilities');
-  $query = 'SELECT $object $title $content
-     FROM <#ri>
-     WHERE {
-            $object $collection_predicate <info:fedora/' . $object->id . '> ;
-                   <fedora-model:label> $title ;
-                   <fedora-model:hasModel> $content ;
-                   <fedora-model:state> <fedora-model:Active> .
-            FILTER(sameTerm($collection_predicate, <fedora-rels-ext:isMemberOfCollection>) || sameTerm($collection_predicate, <fedora-rels-ext:isMemberOf>))
-            FILTER (!sameTerm($content, <info:fedora/fedora-system:FedoraObject-3.0>))';
-  $enforced = variable_get('islandora_namespace_restriction_enforced', FALSE);
-  if ($enforced) {
-    $namespace_array = islandora_get_allowed_namespaces();
-    $namespace_sparql = implode('|', $namespace_array);
-    $query .= 'FILTER(regex(str(?object), "info:fedora/(' . $namespace_sparql . '):"))';
-  }
-  $query .= '} ORDER BY $title';
-  $query_array = array(
-    'query' => $query,
-    'type' => 'sparql',
-    'pid' => $object->id,
-    // Seems as though this is ignored completely.
-    'page_size' => $page_size,
-    'page_number' => $page_number,
-  );
-  drupal_alter('islandora_basic_collection_query', $query_array);
+function islandora_basic_collection_get_member_objects(AbstractObject $object, $page_number = 0, $page_size = 20) {
+  $query_array = islandora_basic_collection_get_query_info(array_combine(
+    array('object', 'page_number', 'page_size'),
+    func_get_args()
+  ));
+
   try {
+    $count = $object->repository->ri->countQuery($query_array['query'], $query_array['type']);
+
+    $is_itql = strcasecmp('itql', $query_array['type']) === 0;
+
+    if ($is_itql && ($page_number > 0 || $page_size >= 0)) {
+      // Strip the final semi-colon(s) of any itql query, where they exist.
+      $query = trim($query_array['query']);
+      while (strpos($query, -1) == ';') {
+        $query = substr($query, 0, -1);
+      }
+      $query_array['query'] = $query;
+    }
+
+    if ($page_number > 0 && $page_size > 0) {
+      // Add in the offset somehow.
+      $offset = $page_number * $page_size;
+      $query_array['query'] .= " offset $offset";
+    }
+    if ($page_size >= 0) {
+      // Add in the limit somehow.
+      $query_array['query'] .= " limit $page_size";
+    }
+
+    if ($is_itql) {
+      // Add in the final semi-colon.
+      $query_array['query'] .= ';';
+    }
+
     $results = $object->repository->ri->query($query_array['query'], $query_array['type']);
   }
   catch (Exception $e) {
+    return FALSE;
+  }
+  return array($count, $results);
+}
+
+/**
+ * Get objects associated with this object.
+ *
+ * Currently, we are only concerned with the with isMemberOf and
+ * isMemberOfCollection relationships.
+ *
+ * @deprecated
+ *   Deprecated in favour of islandora_basic_collection_get_member_objects(),
+ *   which should actually be able to page through results.
+ *
+ * @param AbstractObject $object
+ *   The collection object whose members will be fetched.
+ * @param int $page_number
+ *   The page number in the query for members.
+ * @param int $page_size
+ *   The number of results per page page from the query for members.
+ *
+ * @return array|string
+ *   The array of query results as provided by
+ *   RepositoryQuery::parseSparqlResults().
+ */
+function islandora_basic_collection_get_objects(AbstractObject $object, $page_number = 0, $page_size = -1) {
+  module_load_include('inc', 'islandora', 'includes/utilities');
+  $message = islandora_deprecated('7.x-1.2', 'Use islandora_basic_collection_get_member_objects() to page and avoid potential memory issues with large collections.');
+  trigger_error(filter_xss($message), E_USER_DEPRECATED);
+
+  $new_results = islandora_basic_collection_get_member_objects($object, $page_number, $page_size);
+  if ($new_results) {
+    return $new_results[1];
+  }
+  else {
     drupal_set_message(t('Error getting related objects for %s', array('%s' => $object->id)), 'error');
     return '';
   }
-  return $results;
 }
-
 /**
  * Get all existing collections.
  *

--- a/islandora_basic_collection.module
+++ b/islandora_basic_collection.module
@@ -269,13 +269,18 @@ function islandora_basic_collection_islandora_overview_object(AbstractObject $ob
  * @param array $params
  *   An array containing all the parameters, at least:
  *   - object: An AbstractObject we're querying for.
- *   - page_size: The size of the page/number of results to return.
+ *   but may also contain:
+ *   - page_size: The size of the page/number of results to return. Defaults to
+ *     10.
  *   - page_number: An integer representing the offset as a multiple of
- *     page_size.
+ *     page_size. Defaults to 0.
  *   - vars: A string containing the list of variables to select. Defaults to
  *     "?object ?title".
  *   - order_by: A string indicating which variable by which to sort. Defaults
  *     to "?title". May be set to FALSE to avoid sorting.
+ *   - model: A string representing a URI. Defaults to "?model". Could be
+ *     provided as "<info:fedora/cmodel:pid>" if the type of object to query
+ *     should be filtered.
  *
  * @return array
  *   An array containing a number of keys used to describe the query,
@@ -288,6 +293,13 @@ function islandora_basic_collection_islandora_overview_object(AbstractObject $ob
  *   - pid: The pid of the collection being queried.
  */
 function islandora_basic_collection_get_query_info(array $params) {
+  if (!isset($params['object'])) {
+    throw new Exception(t('!function requires "!object_parameter" to be given in the array of parameters.', array(
+      '!function' => __FUNCTION__,
+      '!object_parameter' => 'object',
+    )));
+  }
+
   // Add in defaults.
   $params += array(
     'page_number' => 0,
@@ -315,10 +327,10 @@ EOQ;
   $query = format_string($query, array(
     '!statements' => implode(' . ', module_invoke_all('islandora_basic_collection_get_query_statements')),
     '!filters' => implode(' ', $filters),
+    '!vars' => $params['vars'],
   ));
 
   $query = format_string($query, array(
-    '!vars' => $params['vars'],
     '!pid' => $object->id,
     '!model' => $params['model'],
   ));

--- a/tests/islandora_collection_web_test_case.inc
+++ b/tests/islandora_collection_web_test_case.inc
@@ -67,7 +67,7 @@ class IslandoraCollectionWebTestCase extends IslandoraWebTestCase {
     $this->drupalPost($path, $edit, t('Delete Collection'));
     $path = $this->url;
     $this->drupalPost($path, $edit, t('Delete'));
-    $this->assertPattern('/Deleted (\w+) children from/', t('Deleted collection directly via PID %pid', array('%pid' => $pid)), t('Islandora'));
+    $this->assertPattern('/(Deleted (\w+) children from|No objects to delete in)/', t('Deleted collection directly via PID %pid', array('%pid' => $pid)), t('Islandora'));
 
     if ($current_user) {
       $this->drupalLogin($current_user);

--- a/theme/theme.inc
+++ b/theme/theme.inc
@@ -19,8 +19,8 @@ function islandora_basic_collection_preprocess_islandora_basic_collection_wrappe
   $page_number = (empty($_GET['page'])) ? 0 : $_GET['page'];
   $page_size = (empty($_GET['pagesize'])) ? variable_get('islandora_basic_collection_page_size', '10') : $_GET['pagesize'];
   $islandora_object = $variables['islandora_object'];
-  $results = islandora_basic_collection_get_objects($islandora_object, $page_number, $page_size);
-  $total_count = count($results);
+  list($total_count, $results) = islandora_basic_collection_get_member_objects($islandora_object, $page_number, $page_size);
+
   pager_default_initialize($total_count, $page_size);
   $variables['collection_pager'] = theme('pager', array('quantity' => 10));
   $display = (empty($_GET['display'])) ? variable_get('islandora_basic_collection_default_view', 'grid') : $_GET['display'];


### PR DESCRIPTION
Large collections would cause PHP memory issues, as we tried to load an entire collection into memory to get the count, before being sliced...

...  Will probably want to look at the other batches in the future, as they will try to query with a deprecated method if they are called without any children. Fixed the delete one, as it gets called in the tests.
