### PR TITLE
initial HHVM compatibility fixes

### DIFF
--- a/includes/collection_policy.inc
+++ b/includes/collection_policy.inc
@@ -47,7 +47,9 @@ EOT;
     $this->xml = new DOMDocument();
     $this->xml->loadXML($xml);
     $path = drupal_get_path('module', 'islandora_basic_collection');
-    if (!$this->xml->schemaValidate("$path/xml/collection_policy.xsd")) {
+    $xsd = file_get_contents("$path/xml/collection_policy.xsd"); 
+    if (!$this->xml->schemaValidateSource($xsd)) {
+      
       throw new InvalidArgumentException('The given collection policy is not valid.');
     }
   }


### PR DESCRIPTION
HHVM xml libs do not support loading files through ->schemaValidate . with this modification islandora (mostly) works under HHVM
