### PR TITLE
ISLANDORA-1522 global UUID setting enforcement

### DIFF
--- a/islandora_basic_collection.module
+++ b/islandora_basic_collection.module
@@ -769,7 +769,7 @@ function islandora_basic_collection_form_islandora_repository_admin_alter(&$form
     '#type' => 'checkbox',
     '#title' => t('UUID PID Generation'),
     '#default_value' => variable_get('islandora_basic_collection_generate_uuid', FALSE),
-    '#description' => t('Generate Fedora object PIDs with v4 UUIDs. Only applies during standard ingest process.'),
+    '#description' => t('Generate Fedora object PIDs with v4 UUIDs.'),
   );
 }
 


### PR DESCRIPTION
Addresses https://jira.duraspace.org/browse/ISLANDORA-1522

Updates UUID PID Generation setting #description. Now all objects
created by Islandora respect UUID.
