### PR TITLE
Add helper function.

### DIFF
--- a/includes/utilities.inc
+++ b/includes/utilities.inc
@@ -121,11 +121,8 @@ function islandora_basic_collection_get_children_select_table_form_element(Abstr
           '#title' => $label,
           '#href' => "islandora/object/{$pid}")));
   }
-  // Theme pager doesn't support url fragments in D7 so we insert manually.
   $pager = theme('pager', array('quantity' => 10, 'element' => $pager_options['element']));
-  $pattern = '/href="([^"]+)"/';
-  $replace = 'href="\1' . $pager_options['fragment'] . '"';
-  $pager = preg_replace($pattern, $replace, $pager);
+  $pager = islandora_basic_collection_append_fragment_to_pager_url($pager, $pager_options['fragment']);
   return array(
     '#type' => 'tableselect',
     '#header' => array(
@@ -240,4 +237,24 @@ function islandora_basic_collection_display_query_sparql($collection_object, $pa
     return $result['object']['value'];
   };
   return array($total, array_map($map_to_pids, $results));
+}
+
+/**
+ * Helper function to add fragment identifiers to pager URLs.
+ *
+ * Theme pager doesn't support url fragments in D7 so we insert manually.
+ *
+ * @param string $pager
+ *   The pager markup to be rendered.
+ * @param string $fragment
+ *   The fragment identifier to be appended.
+ *
+ * @return string
+ *   The pager markup to be rendered with fragment.
+ */
+function islandora_basic_collection_append_fragment_to_pager_url($pager, $fragment) {
+  $pattern = '/href="([^"]+)"/';
+  $replace = format_string('href="\1!fragment"', array('!fragment' => $fragment));
+  $pager = preg_replace($pattern, $replace, $pager);
+  return $pager;
 }


### PR DESCRIPTION
**JIRA:** https://jira.duraspace.org/browse/ISLANDORA-1515
# What does this Pull Request do?

Adds a helper function that can be re-used to facilitate fragment URLs in pagers. This primarily pops up when trying to retain focus in vertical tabs.
# How should this be tested?

Go to yoursite/islandora/object/somecollectionobject/collection, the fragment URLs are appended correctly to the pager links.
# Is there any background context you want to provide?

This helper function came out of the code review generated on https://github.com/Islandora/islandora_xacml_editor/pull/128.

**Tagging:** @willtp87 
