### PR TITLE
ISLANDORA-1571 Optionally manage more than 10 children at a time.

### DIFF
--- a/includes/admin.form.inc
+++ b/includes/admin.form.inc
@@ -39,13 +39,6 @@ function islandora_basic_collection_admin(array $form, array &$form_state) {
           '#default_value' => variable_get('islandora_basic_collection_page_size', '12'),
           '#description' => t('The default number of objects to show in a collection view.'),
         ),
-        'islandora_basic_collection_admin_page_size' => array(
-          '#type' => 'textfield',
-          '#title' => t('Default collection objects per page in the admin view'),
-          '#default_value' => variable_get('islandora_basic_collection_admin_page_size', '10'),
-          '#description' => t('The default number of objects to show in the migrate/share/delete interface.'),
-          '#element_validate' => array('element_validate_integer_positive'),
-        ),
         'islandora_basic_collection_disable_count_object' => array(
           '#type' => 'checkbox',
           '#title' => t('Disable object count query in collection view'),
@@ -75,7 +68,14 @@ function islandora_basic_collection_admin(array $form, array &$form_state) {
       '#default_value' => variable_get('islandora_basic_collection_disable_display_generation', FALSE),
       '#description' => t("Disabling display generation allows for alternate collection displays to be used."),
     ),
-
+    'islandora_basic_collection_admin_page_size' => array(
+      '#type' => 'textfield',
+      '#title' => t('Objects per page during collection management'),
+      '#default_value' => variable_get('islandora_basic_collection_admin_page_size', '10'),
+      '#description' => t('The number of child objects to show per page in the migrate/share/delete interface.'),
+      '#element_validate' => array('element_validate_integer_positive'),
+      '#required' => TRUE,
+    ),
     'islandora_basic_collection_disable_collection_policy_delete' => array(
       '#type' => 'checkbox',
       '#title' => t('Disable deleting the collection policy'),

--- a/includes/admin.form.inc
+++ b/includes/admin.form.inc
@@ -39,6 +39,13 @@ function islandora_basic_collection_admin(array $form, array &$form_state) {
           '#default_value' => variable_get('islandora_basic_collection_page_size', '12'),
           '#description' => t('The default number of objects to show in a collection view.'),
         ),
+        'islandora_basic_collection_admin_page_size' => array(
+          '#type' => 'textfield',
+          '#title' => t('Default collection objects per page in the admin view'),
+          '#default_value' => variable_get('islandora_basic_collection_admin_page_size', '10'),
+          '#description' => t('The default number of objects to show in the migrate/share/delete interface.'),
+          '#element_validate' => array('element_validate_integer_positive'),
+        ),
         'islandora_basic_collection_disable_count_object' => array(
           '#type' => 'checkbox',
           '#title' => t('Disable object count query in collection view'),

--- a/includes/utilities.inc
+++ b/includes/utilities.inc
@@ -94,7 +94,7 @@ function islandora_basic_collection_get_namespace_form_element($default_value) {
 function islandora_basic_collection_get_children_select_table_form_element(AbstractObject $object, array $pager_options) {
   // Assumes all results are returned although the function description
   // states otherwise.
-  $limit = 10;
+  $limit = variable_get('islandora_basic_collection_admin_page_size', 10);
   $page = pager_find_page($pager_options['element']);
   list($count, $results) = islandora_basic_collection_get_member_objects($object, $page, $limit, 'manage');
   $page = pager_default_initialize($count, $limit, $pager_options['element']);
@@ -121,7 +121,7 @@ function islandora_basic_collection_get_children_select_table_form_element(Abstr
           '#title' => $label,
           '#href' => "islandora/object/{$pid}")));
   }
-  $pager = theme('pager', array('quantity' => 10, 'element' => $pager_options['element']));
+  $pager = theme('pager', array('quantity' => $limit, 'element' => $pager_options['element']));
   $pager = islandora_basic_collection_append_fragment_to_pager_url($pager, $pager_options['fragment']);
   return array(
     '#type' => 'tableselect',

--- a/islandora_basic_collection.install
+++ b/islandora_basic_collection.install
@@ -33,6 +33,7 @@ function islandora_basic_collection_uninstall() {
     'islandora_basic_collection_object_count_listing_placeholder',
     'islandora_basic_collection_display_backend',
     'islandora_basic_collection_disable_display_generation',
+    'islandora_basic_collection_admin_page_size',
   );
   array_walk($variables, 'variable_del');
 }


### PR DESCRIPTION
**Jira:** [ISLANDORA-1571](https://jira.duraspace.org/browse/ISLANDORA-1571)
# What does this Pull Request do?

This pull request would allow an admin to perform collection management tasks (share, migrate, delete) on more than 10 child objects at a time.
# How should this be tested?

The default value of 10 can be changed at admin/islandora/solution_pack_config/basic_collection. Any non-positive integer should fail validation. This should allow the batch management of many objects at once. 
# Open questions

Are there known issues with stability when managing more large batches using the current delete functions? At what point does this become an issue?
# Background context:

This is a common complaint, and was pointed out by A. Lakshmi on the Islandora mailing list, https://groups.google.com/forum/#!topic/islandora/O54FQMLBSpA 
# Additional Notes:
- **Could this impact execution of existing code?**
  A large operation could hold up the Fedora repository for a while, but hopefully won't be done too often. 

I think this issue has been discussed in the past but I can't find documentation of it. If you know where, please leave a link in the comments. 

---

Rosie Le Faive
