### PR TITLE
added ability to remove an object from a collection on the overview (…

### DIFF
--- a/includes/utilities.inc
+++ b/includes/utilities.inc
@@ -258,3 +258,25 @@ function islandora_basic_collection_append_fragment_to_pager_url($pager, $fragme
   $pager = preg_replace($pattern, $replace, $pager);
   return $pager;
 }
+
+/**
+ * Wrapper function to call islandora_basic_collection_remove_from_collection() and then 
+ * redirect to the islandora/object/%islandora_object/manage page.
+ * see islandora_basic_collection_remove_from_collection for details on parameters
+ * 
+ * @param AbstractObject $member
+ * @param AbstractObject $collection
+ * 
+ */
+function islandora_basic_collection_remove_from_collection_wrapper(AbstractObject $member, AbstractObject $collection) {
+  islandora_basic_collection_remove_from_collection($member, $collection);
+  // check to see that the object was removed from the collection -- set the message and redirect 
+  $results = $member->relationships->get(FEDORA_RELS_EXT_URI, 'isMemberOfCollection', $collection->id);
+  if (empty($results)) {
+    drupal_set_message("'".$member->id.t("' has been removed from '").$collection->id."'.");
+  } else {
+    drupal_set_message(t("There was a problem removing '".$member->id.t("' from '").$collection->id."'."));
+  }
+  drupal_goto("islandora/object/{$member->id}/manage");
+}
+

--- a/islandora_basic_collection.module
+++ b/islandora_basic_collection.module
@@ -9,6 +9,7 @@
 define('ISLANDORA_BASIC_COLLECTION_CREATE_CHILD_COLLECTION', 'create child collection');
 define('ISLANDORA_BASIC_COLLECTION_MANAGE_COLLECTION_POLICY', 'manage collection policy');
 define('ISLANDORA_BASIC_COLLECTION_MIGRATE_COLLECTION_MEMBERS', 'migrate collection members');
+define('ISLANDORA_BASIC_COLLECTION_REMOVE_FROM_COLLECTION', 'remove object from collection');
 
 const ISLANDORA_BASIC_COLLECTION_LEGACY_BACKEND = 'islandora_basic_collection_legacy_sparql';
 
@@ -78,6 +79,14 @@ function islandora_basic_collection_menu() {
       'type' => MENU_CALLBACK,
       'file' => 'includes/blocks.inc',
     ),
+    'islandora/object/%islandora_object/manage/removeAsParent/%islandora_object' => array(
+      'title' => 'Remove this parent Object',
+      'page callback' => 'islandora_basic_collection_remove_from_collection_wrapper',
+      'page arguments' => array(2, 5), 
+     'type' => MENU_CALLBACK,
+      'file' => 'includes/utilities.inc',
+      'access arguments' => array(ISLANDORA_BASIC_COLLECTION_REMOVE_FROM_COLLECTION),
+    ),     
   );
 }
 
@@ -446,17 +455,20 @@ function islandora_basic_collection_islandora_collectionCModel_islandora_overvie
 function islandora_basic_collection_islandora_overview_object(AbstractObject $object) {
   module_load_include('inc', 'islandora_basic_collection', 'includes/utilities');
   if (!in_array('islandora:collectionCModel', $object->models)) {
-    $map_to_row = function($o) {
-      $o = islandora_object_load($o);
-      return ($o ?
-        array(l($o->label, "islandora/object/{$o->id}")) :
-        FALSE);
-    };
     $pids = islandora_basic_collection_get_parent_pids($object);
-    $rows = array_map($map_to_row, $pids);
+    $rows = array();
+    $hasRemovePerm = user_access(ISLANDORA_BASIC_COLLECTION_REMOVE_FROM_COLLECTION);
+    foreach ($pids as $pid) {
+      $parentObject = islandora_object_load($pid);
+      if ($parentObject) {
+        $rows[] = array(
+            l($parentObject->label, "islandora/object/{$parentObject->id}"),
+            (($hasRemovePerm) ? l(t('remove'), "islandora/object/{$object->id}/manage/removeAsParent/{$parentObject->id}") : NULL) );
+      }
+    }
     $rows = array_filter($rows);
     $table = theme('table', array(
-               'header' => array(t('Parent Collections')),
+               'header' => array(t('Parent Collections'), (($hasRemovePerm) ? t('Operations') : NULL) ),
                'rows' => $rows,
                'empty' => t('No parent collections')));
     return array('collection' => $table);
@@ -731,6 +743,10 @@ function islandora_basic_collection_permission() {
       'title' => t('Migrate collection members'),
       'description' => t('Move objects from one collection to another.'),
     ),
+    ISLANDORA_BASIC_COLLECTION_REMOVE_FROM_COLLECTION => array(
+      'title' => t('Remove object from collection'),
+      'description' => t('Remove an object from a collection.'),
+    ),   
   );
 }
 


### PR DESCRIPTION
**JIRA Ticket**: (link)
N/A - this is an enhancement.
- Other Relevant Links (Google Groups discussion, related pull requests, Release pull requests, etc.)
# What does this Pull Request do?

added ability to remove an object from a collection
# What's new?

A in-depth description of the changes made by this PR. Technical details and possible side effects.
On the overview [manage] page, there is a new link and heading "OPERATIONS" for the table that renders for islandora objects.  This link is displayed for any parent object collections so that they can be removed right from this screen.

Example:
- Changes x feature to such that y
- Added x
- Removed y
# How should this be tested?

To test, add another parent collection to any child object (convenient to use "+ Share this Object with another collection" after other collection types are configured to have your test models under the Collection Policy).  Remove the relationship to the collection by clicking the "remove" link on the object's Manage | overview page.

A description of what steps someone could take to:
- Reproduce the problem you are fixing (if applicable)
- Test that the Pull Request does what is intended.
- Please be as detailed as possible.
- Good testing instructions help get your PR completed faster.
# Additional Notes:

This could require a minor documentation change.  I am not familiar with that side of things.
