### PR TITLE
fixing collection count query stuff

### DIFF
--- a/includes/admin.form.inc
+++ b/includes/admin.form.inc
@@ -41,9 +41,9 @@ function islandora_basic_collection_admin(array $form, array &$form_state) {
         ),
         'islandora_basic_collection_disable_count_object' => array(
           '#type' => 'checkbox',
-          '#title' => t('Disable object count query in collection view'),
+          '#title' => t('Disable object count query in collection overview'),
           '#default_value' => variable_get('islandora_basic_collection_disable_count_object', FALSE),
-          '#description' => t("Disabling the object count query can improve performance when viewing large collections"),
+          '#description' => t("Disabling the object count query can improve performance when loading the overview for large collections."),
         ),
         'islandora_basic_collection_default_view' => array(
           '#type' => 'select',

--- a/islandora_basic_collection.module
+++ b/islandora_basic_collection.module
@@ -389,9 +389,6 @@ function islandora_basic_collection_islandora_collectionCModel_islandora_overvie
     'fedora-system:FedoraObject-3.0',
   );
   $disable_count = variable_get('islandora_basic_collection_disable_count_object', FALSE);
-  if (!$disable_count) {
-    $total = 0;
-  }
   foreach ($models as $model) {
     $model_pid = $model['model']['value'];
     if (in_array($model_pid, $ignore_models)) {

--- a/islandora_basic_collection.module
+++ b/islandora_basic_collection.module
@@ -243,8 +243,8 @@ function islandora_basic_collection_islandora_collectionCModel_islandora_view_ob
     }
     else {
       $limit = ((empty($_GET['pagesize'])) ?
-               variable_get('islandora_basic_collection_page_size', '12') :
-               $_GET['pagesize']);
+        variable_get('islandora_basic_collection_page_size', '12') :
+        $_GET['pagesize']);
       $pager_element = 0;
       $passed_page = pager_find_page($pager_element);
       if (isset($backends[$backend]['file'])) {
@@ -388,6 +388,10 @@ function islandora_basic_collection_islandora_collectionCModel_islandora_overvie
   $ignore_models = array(
     'fedora-system:FedoraObject-3.0',
   );
+  $disable_count = variable_get('islandora_basic_collection_disable_count_object', FALSE);
+  if (!$disable_count) {
+    $total = 0;
+  }
   foreach ($models as $model) {
     $model_pid = $model['model']['value'];
     if (in_array($model_pid, $ignore_models)) {
@@ -401,39 +405,27 @@ function islandora_basic_collection_islandora_collectionCModel_islandora_overvie
       'model' => "<info:fedora/$model_pid>",
     ));
     $model_object = islandora_object_load($model_pid);
-    if (variable_get('islandora_basic_collection_disable_count_object', FALSE)) {
-      $rows[$model_pid] = array(
-        ($model_object ?
-            l($model_object->label, "islandora/object/{$model_object->id}") :
-            $model_pid),
-      );
-    }
-    else {
-      $rows[$model_pid] = array(
-        ($model_object ?
-            l($model_object->label, "islandora/object/{$model_object->id}") :
-            $model_pid),
-        $object->repository->ri->countQuery($model_count_query['query'], $model_count_query['type']),
-      );
+    $rows[$model_pid] = array(
+      $model_object ? l($model_object->label, "islandora/object/{$model_object->id}") : $model_pid,
+    );
+    if (!$disable_count) {
+      $rows[$model_pid][] = $object->repository->ri->countQuery($model_count_query['query'], $model_count_query['type']);
     }
   }
 
-  list($total_count, $all_results) = islandora_basic_collection_get_member_objects($object, 0, 0);
-
   $content = array(
-    'total' => array('#markup' => t('Total members: %total', array('%total' => $total_count))),
     'table' => array(
       '#theme' => 'table',
       '#header' => array(
         'type' => array('data' => t('Type')),
-        'count' => array('data' => t('Count')),
       ),
       '#rows' => $rows,
       '#empty' => t('Collection is empty.')),
   );
-  if (variable_get('islandora_basic_collection_disable_count_object', FALSE)) {
-    unset($content['total']);
-    unset($content['table']['#header']['count']);
+  if (!$disable_count) {
+    list($total_count, $all_results) = islandora_basic_collection_get_member_objects($object, 0, 0);
+    $content['total'] = array('#markup' => t('Total members: %total', array('%total' => $total_count)));
+    $content['table']['#header']['count'] = array('data' => t('Count'));
   }
   return array(
     'collection' => drupal_render($content),
@@ -624,7 +616,7 @@ function islandora_basic_collection_get_member_objects(AbstractObject $object, $
   }
   $query_array = islandora_basic_collection_get_query_info($params, $type);
   try {
-    $count = variable_get('islandora_basic_collection_disable_count_object', FALSE) ? 0 : $object->repository->ri->countQuery($query_array['query'], $query_array['type']);
+    $count = $object->repository->ri->countQuery($query_array['query'], $query_array['type']);
     $is_itql = strcasecmp('itql', $query_array['type']) === 0;
 
     if ($is_itql && ($page_number > 0 || $page_size >= 0)) {


### PR DESCRIPTION
**JIRA Ticket**: https://jira.duraspace.org/browse/ISLANDORA-1745
# What does this Pull Request do?

So, checking off the 'Disable object count query in collection view' box in the collection admin page causes a couple problems - it breaks collection pagination, and it doesn't actually give the speed boost on the overview page that it promises.
# What's new?
1. Disabling the collection count query no longer breaks pagination on collections in the view and management sections.
2. Disabling the collection count query appropriately gives the speed boost on the collection overview that it promises.
3. The description on the admin page now correctly describes the feature.
# How should this be tested?

You can reproduce the problem by going to the collection view page, or by going to the collection management page and trying the 'share/move/delete' tabs. After checking off the 'Disable object count query in collection view' box in the collection admin page, the pager disappears. This fix should stop that from happening.

It should also make the management overview page load faster for very large collections, though that's a bit more difficult to test
# Additional Notes:

We can't really disable 'counting' on the view/collection management pages anyway; without knowing the total number of items in a collection, there's absolutely no way to build a pager, and the collection view is rendered useless.

The only place that a collection 'count' seems to appear is on the collection management overview page, so this pull should give that checkbox's reported functionality more accuracy.
# Interested parties

@willtp87 is the maintainer here.
