### PR TITLE
ISLANDORA-1753 - bad collection policy

### DIFF
--- a/includes/manage_collection.inc
+++ b/includes/manage_collection.inc
@@ -208,6 +208,21 @@ function islandora_basic_collection_create_child_collection_form_submit(array $f
 }
 
 /**
+ * Undo setting the content model
+ *
+ * @param array $form
+ *   The Drupal form definition.
+ * @param array $form_state
+ *   The Drupal form state.
+ */
+function islandora_basic_collection_create_child_collection_form_undo_submit(&$form, &$form_state) {
+  $object = $form_state['islandora']['objects'][0];
+  if (isset($object['COLLECTION_POLICY'])) {
+    $object->purgeDatastream('COLLECTION_POLICY');
+  }
+}
+
+/**
  * Define collection policy management form.
  *
  * @param array $form

--- a/includes/manage_collection.inc
+++ b/includes/manage_collection.inc
@@ -208,7 +208,7 @@ function islandora_basic_collection_create_child_collection_form_submit(array $f
 }
 
 /**
- * Undo setting the content model
+ * Undo setting the COLLECTION_POLICY.
  *
  * @param array $form
  *   The Drupal form definition.
@@ -216,7 +216,7 @@ function islandora_basic_collection_create_child_collection_form_submit(array $f
  *   The Drupal form state.
  */
 function islandora_basic_collection_create_child_collection_form_undo_submit(&$form, &$form_state) {
-  $object = $form_state['islandora']['objects'][0];
+  $object = islandora_ingest_form_get_object($form_state);
   if (isset($object['COLLECTION_POLICY'])) {
     $object->purgeDatastream('COLLECTION_POLICY');
   }

--- a/includes/manage_collection.inc
+++ b/includes/manage_collection.inc
@@ -107,7 +107,7 @@ function islandora_basic_collection_islandora_basic_collection_build_manage_obje
 function islandora_basic_collection_create_child_collection_form(array $form, array &$form_state) {
   module_load_include('inc', 'islandora', 'includes/utilities');
 
-  // if the form has step_storage values set, use them instead of the defaults
+  // If the form has step_storage values set, use them instead of the defaults.
   $step_storage = &islandora_ingest_form_get_step_storage($form_state, 'islandora_basic_collection');
   $form_values = isset($step_storage['values']) ? $step_storage['values'] : NULL;
 
@@ -117,17 +117,13 @@ function islandora_basic_collection_create_child_collection_form(array $form, ar
     drupal_set_message(t('You do not have permissions to create collections.'), 'error');
     drupal_goto('islandora/object/' . $parent_object->id);
   }
-
   $policy = new CollectionPolicy($parent_object['COLLECTION_POLICY']->content);
   $policy_content_models = $policy->getContentModels();
   $content_models = islandora_get_content_models();
   $form_state['content_models'] = $content_models;
   $default_namespace = islandora_get_namespace($policy_content_models['islandora:collectionCModel']['namespace']);
   $the_namespace = isset($form_values['namespace']) ? $form_values['namespace'] : $default_namespace;
-
-  $content_models_values = isset($form_values['content_models'])
-    ? array_filter($form_values['content_models'])
-    : array();
+  $content_models_values = isset($form_values['content_models']) ? array_filter($form_values['content_models']) : array();
 
   return array(
     '#action' => request_uri() . '#create-child-collection',

--- a/includes/manage_collection.inc
+++ b/includes/manage_collection.inc
@@ -106,17 +106,29 @@ function islandora_basic_collection_islandora_basic_collection_build_manage_obje
  */
 function islandora_basic_collection_create_child_collection_form(array $form, array &$form_state) {
   module_load_include('inc', 'islandora', 'includes/utilities');
+
+  // if the form has step_storage values set, use them instead of the defaults
+  $step_storage = &islandora_ingest_form_get_step_storage($form_state, 'islandora_basic_collection');
+  $form_values = isset($step_storage['values']) ? $step_storage['values'] : NULL;
+
   $parent_object = islandora_object_load($form_state['islandora']['shared_storage']['parent']);
   // Permissions handling.
   if (!user_access(ISLANDORA_BASIC_COLLECTION_CREATE_CHILD_COLLECTION)) {
     drupal_set_message(t('You do not have permissions to create collections.'), 'error');
     drupal_goto('islandora/object/' . $parent_object->id);
   }
+
   $policy = new CollectionPolicy($parent_object['COLLECTION_POLICY']->content);
   $policy_content_models = $policy->getContentModels();
   $content_models = islandora_get_content_models();
   $form_state['content_models'] = $content_models;
   $default_namespace = islandora_get_namespace($policy_content_models['islandora:collectionCModel']['namespace']);
+  $the_namespace = isset($form_values['namespace']) ? $form_values['namespace'] : $default_namespace;
+
+  $content_models_values = isset($form_values['content_models'])
+    ? array_filter($form_values['content_models'])
+    : array();
+
   return array(
     '#action' => request_uri() . '#create-child-collection',
     'pid' => array(
@@ -124,11 +136,12 @@ function islandora_basic_collection_create_child_collection_form(array $form, ar
       '#title' => t('Collection PID'),
       '#description' => t("Unique PID for this collection. Leave blank to use the default.<br/>PIDs take the general form of <strong>namespace:collection</strong> (e.g., islandora:pamphlets)"),
       '#size' => 15,
+      '#default_value' => isset($form_values['pid']) ? $form_values['pid'] : '',
     ),
     'inherit_policy' => array(
       '#type' => 'checkbox',
       '#title' => t('Inherit collection policy?'),
-      '#default_value' => TRUE,
+      '#default_value' => isset($form_values['inherit_policy']) ? $form_values['inherit_policy'] == 1 : TRUE,
     ),
     'policy' => array(
       '#type' => 'fieldset',
@@ -138,11 +151,12 @@ function islandora_basic_collection_create_child_collection_form(array $form, ar
           ':input[name="inherit_policy"]' => array('checked' => FALSE),
         ),
       ),
-      'namespace' => islandora_basic_collection_get_namespace_form_element($default_namespace),
+      'namespace' => islandora_basic_collection_get_namespace_form_element($the_namespace),
       'content_models' => array(
         '#title' => "Allowable content models",
         '#type' => 'checkboxes',
         '#options' => islandora_basic_collection_get_content_models_as_form_options($content_models),
+        '#default_value' => $content_models_values,
         '#description' => t("Content models describe the behaviours of objects with which they are associated."),
       ),
     ),
@@ -182,6 +196,7 @@ function islandora_basic_collection_create_child_collection_form_validate(array 
  */
 function islandora_basic_collection_create_child_collection_form_submit(array $form, array &$form_state) {
   module_load_include('inc', 'islandora', 'includes/utilities');
+
   // Prepare Object.
   $new_collection = $form_state['islandora']['objects'][0];
   if (!empty($form_state['values']['pid'])) {
@@ -205,21 +220,28 @@ function islandora_basic_collection_create_child_collection_form_submit(array $f
   $policy_datastream->setContentFromString($collection_policy);
   $policy_datastream->label = 'Collection policy';
   $new_collection->ingestDatastream($policy_datastream);
+
+  $step_storage = &islandora_ingest_form_get_step_storage($form_state, 'islandora_basic_collection');
+  $step_storage['created']['COLLECTION_POLICY'] = TRUE;
 }
 
 /**
- * Undo setting the COLLECTION_POLICY.
+ * Undo setting the COLLECTION_POLICY, purging the datastream that was created.
  *
  * @param array $form
  *   The Drupal form definition.
  * @param array $form_state
  *   The Drupal form state.
  */
-function islandora_basic_collection_create_child_collection_form_undo_submit(&$form, &$form_state) {
+function islandora_basic_collection_create_child_collection_form_undo_submit(array &$form, array &$form_state) {
+  $step_storage = &islandora_ingest_form_get_step_storage($form_state, 'islandora_basic_collection');
   $object = islandora_ingest_form_get_object($form_state);
-  if (isset($object['COLLECTION_POLICY'])) {
-    $object->purgeDatastream('COLLECTION_POLICY');
+  foreach ($step_storage['created'] as $dsid => $created) {
+    if ($created) {
+      $object->purgeDatastream($dsid);
+    }
   }
+  unset($step_storage['created']);
 }
 
 /**


### PR DESCRIPTION
**JIRA Ticket**: [ISLANDORA-1753](https://jira.duraspace.org/browse/ISLANDORA-1753)
# What does this Pull Request do?

When using the paging feature in a Collection ingest, the COLLECTION_POLICY can be created with unexpected content models selected. 
# What's new?

Added a form handler to reset the COLLECTION_POLICY when paging back, so the correct policy will be ingested.
# How should this be tested?
- Begin a Collection object ingest.
- Adjust the collection policy.
- Go forward to the next step.
- Go back, and make further adjustments to the policy.
- Go forward, completing the ingest.
- Check the Collection view and ensure that the COLLECTION_POLICY reflects the last set of selected content models.  May also check the COLLECTION_POLICY datastream to verify the expected content_models.
# Interested parties

@willtp87 is the maintainer.
