### PR TITLE
Move collection picker beside submit button when sharing/migrating.

### DIFF
--- a/includes/manage_collection.inc
+++ b/includes/manage_collection.inc
@@ -317,16 +317,16 @@ function islandora_basic_collection_share_children_form(array $form, array &$for
   $fragment = '#share-children';
   return array(
     '#action' => request_uri() . $fragment,
+    'children' => islandora_basic_collection_get_children_select_table_form_element($object, array(
+      'element' => 0,
+      'fragment' => $fragment,
+    )),
     'collection' => array(
       '#title' => t('Share members with collection'),
       '#description' => t("Members can be shared with any number of collections."),
       '#type' => 'select',
       '#options' => islandora_basic_collection_get_other_collections_as_form_options($object),
     ),
-    'children' => islandora_basic_collection_get_children_select_table_form_element($object, array(
-      'element' => 0,
-      'fragment' => $fragment,
-    )),
     'submit' => array(
       '#type' => 'submit',
       '#value' => t('Share selected objects'),
@@ -379,16 +379,16 @@ function islandora_basic_collection_migrate_children_form(array $form, array &$f
   $fragment = '#migrate-children';
   return array(
     '#action' => request_uri() . $fragment,
+    'children' => islandora_basic_collection_get_children_select_table_form_element($object, array(
+      'element' => 1,
+      'fragment' => $fragment,
+    )),
     'collection' => array(
       '#title' => t('Migrate members to collection'),
       '#description' => t('Removes members from their current collection (%label) and adds them to the selected collection.', array('%label' => $object->label)),
       '#type' => 'select',
       '#options' => islandora_basic_collection_get_other_collections_as_form_options($object),
     ),
-    'children' => islandora_basic_collection_get_children_select_table_form_element($object, array(
-      'element' => 1,
-      'fragment' => $fragment,
-    )),
     'submit' => array(
       '#type' => 'submit',
       '#value' => t('Migrate selected objects'),


### PR DESCRIPTION
**JIRA Ticket**: https://jira.duraspace.org/browse/ISLANDORA-1766
# What does this Pull Request do?

Aligns the share and migrate forms with commonly-expressed new user expectations.  Hopefully reduces the likelihood of moving a bunch of objects to the wrong collection.
# What's new?

Moved the collection picker dropdown to the bottom of the form when sharing/migrating the children of a collection, so that the user is prompted to select the objects to move, then the destination to move them to. 
# How should this be tested?

Make sure you can migrate and share objects between collections.
# Additional Notes:
- Will require screenshots/custom documentation to be updated.
- May require official Islandora documentation to be updated (a quick look through the DuraSpace wiki found no screenshots of the migrate/share interfaces).
# Interested parties

@manez as ticket creator / Admin track guru
