### PR TITLE
Added metadata placement for use with the SOLR driven backend display.

### DIFF
--- a/includes/admin.form.inc
+++ b/includes/admin.form.inc
@@ -132,7 +132,7 @@ function islandora_basic_collection_admin(array $form, array &$form_state) {
     ),
   );
 
-  $weights = variable_get('metadata_info_table_drag_attributes', "");
+  $weights = variable_get('metadata_info_table_drag_attributes', NULL);
 
   foreach ($page_content as $key => $data) {
     $form['metadata_display_fieldset']['metadata_info_table_drag_attributes'][$key]['#weight']

--- a/includes/admin.form.inc
+++ b/includes/admin.form.inc
@@ -99,26 +99,24 @@ function islandora_basic_collection_admin(array $form, array &$form_state) {
   // The key's match up with the form elements array keys.
   $page_content = array(
     'description' => array(
-      'name' => "Description",
-      'description' => "An objects description field",
+      'name' => t("Description"),
+      'description' => t("An objects description field"),
     ),
     'collections' => array(
-      'name' => "In Collection",
-      'description' => "Indicates which collections this object belongs to",
+      'name' => t("In Collection"),
+      'description' => t("Indicates which collections this object belongs to"),
     ),
     'wrapper' => array(
-      'name' => "Fieldset Metadata",
-      'description' => "An objects metadata collection set",
+      'name' => t("Fieldset Metadata"),
+      'description' => t("An objects metadata collection set"),
     ),
     'islandora_basic_collection_display' => array(
-      'name' => "Object Content",
-      'description' => "Main object page content, such as configured viewers",
+      'name' => t("Object Content"),
+      'description' => t("Main object page content, such as configured viewers"),
     ),
   );
 
-  $form['metadata_display_fieldset']['metadata_info_table_drag_attributes'] = array(
-    '#prefix' => '<div id="curve-attributes">',
-    '#suffix' => '</div>',
+  $form['metadata_display_fieldset']['islandora_basic_collection_metadata_info_table_drag_attributes'] = array(
     '#theme_wrappers' => array('fieldset'),
     '#tree' => TRUE,
     '#title' => t("Page content placement"),
@@ -132,20 +130,20 @@ function islandora_basic_collection_admin(array $form, array &$form_state) {
     ),
   );
 
-  $weights = variable_get('metadata_info_table_drag_attributes', NULL);
+  $weights = variable_get('islandora_basic_collection_metadata_info_table_drag_attributes', NULL);
 
   foreach ($page_content as $key => $data) {
-    $form['metadata_display_fieldset']['metadata_info_table_drag_attributes'][$key]['#weight']
+    $form['metadata_display_fieldset']['islandora_basic_collection_metadata_info_table_drag_attributes'][$key]['#weight']
       = (!is_null($weights[$key]['weight'])) ? $weights[$key]['weight'] : 0;
-    $form['metadata_display_fieldset']['metadata_info_table_drag_attributes'][$key]['label'] = array(
+    $form['metadata_display_fieldset']['islandora_basic_collection_metadata_info_table_drag_attributes'][$key]['label'] = array(
       '#type' => 'item',
       '#markup' => $data['name'],
     );
-    $form['metadata_display_fieldset']['metadata_info_table_drag_attributes'][$key]['textfield'] = array(
+    $form['metadata_display_fieldset']['islandora_basic_collection_metadata_info_table_drag_attributes'][$key]['textfield'] = array(
       '#type' => 'item',
-      '#markup' => t("@description", array("@description" => $data['description'])),
+      '#markup' => $data['description'],
     );
-    $form['metadata_display_fieldset']['metadata_info_table_drag_attributes'][$key]['weight'] = array(
+    $form['metadata_display_fieldset']['islandora_basic_collection_metadata_info_table_drag_attributes'][$key]['weight'] = array(
       '#type' => 'textfield',
       '#default_value' => (!is_null($weights[$key]['weight'])) ? $weights[$key]['weight'] : 0,
       '#size' => 3,
@@ -155,7 +153,7 @@ function islandora_basic_collection_admin(array $form, array &$form_state) {
         ),
       ),
     );
-    $form['metadata_display_fieldset']['metadata_info_table_drag_attributes'][$key]['omit'] = array(
+    $form['metadata_display_fieldset']['islandora_basic_collection_metadata_info_table_drag_attributes'][$key]['omit'] = array(
       '#type' => 'checkbox',
       '#default_value' => (!is_null($weights[$key]['omit'])) ? $weights[$key]['omit'] : 0,
       '#attributes' => array(

--- a/includes/admin.form.inc
+++ b/includes/admin.form.inc
@@ -135,6 +135,9 @@ function islandora_basic_collection_admin(array $form, array &$form_state) {
   foreach ($page_content as $key => $data) {
     $form['metadata_display_fieldset']['islandora_basic_collection_metadata_info_table_drag_attributes'][$key] = array();
     $element =& $form['metadata_display_fieldset']['islandora_basic_collection_metadata_info_table_drag_attributes'][$key];
+    if (!isset($config[$key])) {
+      $config[$key] = array();
+    }
     $config[$key] += array(
       'weight' => 0,
       'omit' => 0,

--- a/includes/admin.form.inc
+++ b/includes/admin.form.inc
@@ -136,7 +136,7 @@ function islandora_basic_collection_admin(array $form, array &$form_state) {
 
   foreach ($page_content as $key => $data) {
     $form['metadata_display_fieldset']['metadata_info_table_drag_attributes'][$key]['#weight']
-      = (isset($weights[$key]['weight'])) ? $weights[$key]['weight'] : 0;
+      = (!is_null($weights[$key]['weight'])) ? $weights[$key]['weight'] : 0;
     $form['metadata_display_fieldset']['metadata_info_table_drag_attributes'][$key]['label'] = array(
       '#type' => 'item',
       '#markup' => $data['name'],
@@ -147,7 +147,7 @@ function islandora_basic_collection_admin(array $form, array &$form_state) {
     );
     $form['metadata_display_fieldset']['metadata_info_table_drag_attributes'][$key]['weight'] = array(
       '#type' => 'textfield',
-      '#default_value' => (isset($weights[$key]['weight'])) ? $weights[$key]['weight'] : 0,
+      '#default_value' => (!is_null($weights[$key]['weight'])) ? $weights[$key]['weight'] : 0,
       '#size' => 3,
       '#attributes' => array(
         'class' => array(
@@ -157,7 +157,7 @@ function islandora_basic_collection_admin(array $form, array &$form_state) {
     );
     $form['metadata_display_fieldset']['metadata_info_table_drag_attributes'][$key]['omit'] = array(
       '#type' => 'checkbox',
-      '#default_value' => (isset($weights[$key]['omit'])) ? $weights[$key]['omit'] : 0,
+      '#default_value' => (!is_null($weights[$key]['omit'])) ? $weights[$key]['omit'] : 0,
       '#attributes' => array(
         'class' => array(
           'item-row-weight',

--- a/includes/admin.form.inc
+++ b/includes/admin.form.inc
@@ -124,28 +124,34 @@ function islandora_basic_collection_admin(array $form, array &$form_state) {
     '#description' => t('Use the table below to determine the rendering order of page and metadata content.'),
     '#states' => array(
       'visible' => array(
-        ':input[name="islandora_basic_collection_display_backend"]' => array('value' => 'islandora_solr_query_backend'),
+        ':input[name="islandora_basic_collection_display_backend"]' => array('!value' => ISLANDORA_BASIC_COLLECTION_LEGACY_BACKEND),
         ':input[name="islandora_collection_metadata_display"]' => array('checked' => TRUE),
       ),
     ),
   );
 
-  $weights = variable_get('islandora_basic_collection_metadata_info_table_drag_attributes', NULL);
+  $config = variable_get('islandora_basic_collection_metadata_info_table_drag_attributes', array());
 
   foreach ($page_content as $key => $data) {
-    $form['metadata_display_fieldset']['islandora_basic_collection_metadata_info_table_drag_attributes'][$key]['#weight']
-      = (!is_null($weights[$key]['weight'])) ? $weights[$key]['weight'] : 0;
-    $form['metadata_display_fieldset']['islandora_basic_collection_metadata_info_table_drag_attributes'][$key]['label'] = array(
+    $form['metadata_display_fieldset']['islandora_basic_collection_metadata_info_table_drag_attributes'][$key] = array();
+    $element =& $form['metadata_display_fieldset']['islandora_basic_collection_metadata_info_table_drag_attributes'][$key];
+    $config[$key] += array(
+      'weight' => 0,
+      'omit' => 0,
+    );
+
+    $element['#weight'] = $config[$key]['weight'];
+    $element['label'] = array(
       '#type' => 'item',
       '#markup' => $data['name'],
     );
-    $form['metadata_display_fieldset']['islandora_basic_collection_metadata_info_table_drag_attributes'][$key]['textfield'] = array(
+    $element['textfield'] = array(
       '#type' => 'item',
       '#markup' => $data['description'],
     );
-    $form['metadata_display_fieldset']['islandora_basic_collection_metadata_info_table_drag_attributes'][$key]['weight'] = array(
+    $element['weight'] = array(
       '#type' => 'textfield',
-      '#default_value' => (!is_null($weights[$key]['weight'])) ? $weights[$key]['weight'] : 0,
+      '#default_value' => $element['#weight'],
       '#size' => 3,
       '#attributes' => array(
         'class' => array(
@@ -153,9 +159,9 @@ function islandora_basic_collection_admin(array $form, array &$form_state) {
         ),
       ),
     );
-    $form['metadata_display_fieldset']['islandora_basic_collection_metadata_info_table_drag_attributes'][$key]['omit'] = array(
+    $element['omit'] = array(
       '#type' => 'checkbox',
-      '#default_value' => (!is_null($weights[$key]['omit'])) ? $weights[$key]['omit'] : 0,
+      '#default_value' => $config[$key]['omit'],
       '#attributes' => array(
         'class' => array(
           'item-row-weight',

--- a/includes/admin.form.inc
+++ b/includes/admin.form.inc
@@ -94,5 +94,78 @@ function islandora_basic_collection_admin(array $form, array &$form_state) {
       ),
     ),
   );
+
+  // Define the elements that appear on a collection objects display page.
+  // The key's match up with the form elements array keys.
+  $page_content = array(
+    'description' => array(
+      'name' => "Description",
+      'description' => "An objects description field",
+    ),
+    'collections' => array(
+      'name' => "In Collection",
+      'description' => "Indicates which collections this object belongs to",
+    ),
+    'wrapper' => array(
+      'name' => "Fieldset Metadata",
+      'description' => "An objects metadata collection set",
+    ),
+    'islandora_basic_collection_display' => array(
+      'name' => "Object Content",
+      'description' => "Main object page content, such as configured viewers",
+    ),
+  );
+
+  $form['metadata_display_fieldset']['metadata_info_table_drag_attributes'] = array(
+    '#prefix' => '<div id="curve-attributes">',
+    '#suffix' => '</div>',
+    '#theme_wrappers' => array('fieldset'),
+    '#tree' => TRUE,
+    '#title' => t("Page content placement"),
+    '#theme' => 'islandora_basic_collection_metadata_table_drag_components',
+    '#description' => t('Use the table below to determine the rendering order of page and metadata content.'),
+    '#states' => array(
+      'visible' => array(
+        ':input[name="islandora_basic_collection_display_backend"]' => array('value' => 'islandora_solr_query_backend'),
+        ':input[name="islandora_collection_metadata_display"]' => array('checked' => TRUE),
+      ),
+    ),
+  );
+
+  $weights = variable_get('metadata_info_table_drag_attributes', "");
+
+  foreach ($page_content as $key => $data) {
+    $form['metadata_display_fieldset']['metadata_info_table_drag_attributes'][$key]['#weight']
+      = (isset($weights[$key]['weight'])) ? $weights[$key]['weight'] : 0;
+    $form['metadata_display_fieldset']['metadata_info_table_drag_attributes'][$key]['label'] = array(
+      '#type' => 'item',
+      '#markup' => $data['name'],
+    );
+    $form['metadata_display_fieldset']['metadata_info_table_drag_attributes'][$key]['textfield'] = array(
+      '#type' => 'item',
+      '#markup' => t("@description", array("@description" => $data['description'])),
+    );
+    $form['metadata_display_fieldset']['metadata_info_table_drag_attributes'][$key]['weight'] = array(
+      '#type' => 'textfield',
+      '#default_value' => (isset($weights[$key]['weight'])) ? $weights[$key]['weight'] : 0,
+      '#size' => 3,
+      '#attributes' => array(
+        'class' => array(
+          'item-row-weight',
+        ),
+      ),
+    );
+    $form['metadata_display_fieldset']['metadata_info_table_drag_attributes'][$key]['omit'] = array(
+      '#type' => 'checkbox',
+      '#default_value' => (isset($weights[$key]['omit'])) ? $weights[$key]['omit'] : 0,
+      '#attributes' => array(
+        'class' => array(
+          'item-row-weight',
+        ),
+        'title' => t('Hide the selected element from display, marking it as an invisible element in the DOM.'),
+      ),
+    );
+  }
+
   return system_settings_form($form);
 }

--- a/islandora_basic_collection.install
+++ b/islandora_basic_collection.install
@@ -22,6 +22,7 @@ function islandora_basic_collection_uninstall() {
   module_load_include('inc', 'islandora', 'includes/solution_packs');
   islandora_install_solution_pack('islandora_basic_collection', 'uninstall');
   $variables = array(
+    'metadata_info_table_drag_attributes',
     'islandora_basic_collection_generate_uuid',
     'islandora_basic_collection_page_size',
     'islandora_basic_collection_disable_collection_policy_delete',

--- a/islandora_basic_collection.install
+++ b/islandora_basic_collection.install
@@ -22,7 +22,7 @@ function islandora_basic_collection_uninstall() {
   module_load_include('inc', 'islandora', 'includes/solution_packs');
   islandora_install_solution_pack('islandora_basic_collection', 'uninstall');
   $variables = array(
-    'metadata_info_table_drag_attributes',
+    'islandora_basic_collection_metadata_info_table_drag_attributes',
     'islandora_basic_collection_generate_uuid',
     'islandora_basic_collection_page_size',
     'islandora_basic_collection_disable_collection_policy_delete',

--- a/islandora_basic_collection.module
+++ b/islandora_basic_collection.module
@@ -361,10 +361,11 @@ function islandora_basic_collection_islandora_collectionCModel_islandora_view_ob
   $weight_config = variable_get('metadata_info_table_drag_attributes', "");
   if (isset($weight_config)) {
     foreach ($weight_config as $key => $value) {
-      $rendered[$key]['#weight']
-        = $weight_config[$key]['weight'];
-      if ($weight_config[$key]['omit'] > 0) {
-        $rendered[$key]['#attributes']['class'][] = 'element-invisible';
+      if (isset($rendered[$key])) {
+        $rendered[$key]['#weight'] = $weight_config[$key]['weight'];
+        if ($weight_config[$key]['omit'] > 0) {
+          $rendered[$key]['#attributes']['class'][] = 'element-invisible';
+        }
       }
     }
   }

--- a/islandora_basic_collection.module
+++ b/islandora_basic_collection.module
@@ -300,6 +300,7 @@ function islandora_basic_collection_islandora_collectionCModel_islandora_view_ob
     $parent_collections = islandora_get_parents_from_rels_ext($object);
     if (!empty($parent_collections)) {
       $to_return['collections'] = array(
+        '#type' => 'markup',
         '#theme_wrappers' => array('container'),
         '#attributes' => array(
           'class' => array(

--- a/islandora_basic_collection.module
+++ b/islandora_basic_collection.module
@@ -220,6 +220,10 @@ function islandora_basic_collection_theme($existing, $type, $theme, $path) {
       'file' => 'theme/theme.inc',
       'render element' => 'table',
     ),
+    'islandora_basic_collection_metadata_table_drag_components' => array(
+      'render element' => 'element',
+      'file' => 'theme/theme.inc',
+    ),
   );
 }
 
@@ -243,8 +247,8 @@ function islandora_basic_collection_islandora_collectionCModel_islandora_view_ob
     }
     else {
       $limit = ((empty($_GET['pagesize'])) ?
-               variable_get('islandora_basic_collection_page_size', '12') :
-               $_GET['pagesize']);
+        variable_get('islandora_basic_collection_page_size', '12') :
+        $_GET['pagesize']);
       $pager_element = 0;
       $passed_page = pager_find_page($pager_element);
       if (isset($backends[$backend]['file'])) {
@@ -267,60 +271,104 @@ function islandora_basic_collection_islandora_collectionCModel_islandora_view_ob
           '#limit' => $limit,
           '#pager_element' => $pager_element,
           '#display' => variable_get('islandora_basic_collection_default_view', 'grid'),
+          '#theme_wrappers' => array('container'),
+          '#attributes' => array(
+            'class' => array(
+              'islandora-solr-collection-display',
+            ),
+          ),
         ),
       );
     }
   }
 
+  // Add collection description metadata.
   if (variable_get('islandora_collection_metadata_display', FALSE)) {
     module_load_include('inc', 'islandora', 'includes/metadata');
-    $to_return['wrapper'] = array(
-      '#type' => 'item',
+
+    $to_return['description'] = array(
+      '#type' => 'markup',
       '#theme_wrappers' => array('container'),
-      '#attached' => array(
-        'js' => array(
-          'misc/form.js',
-          'misc/collapse.js',
-        ),
-      ),
       '#attributes' => array(
         'class' => array(
           'islandora-collection-metadata',
+          'islandora-collection-metadata-description',
         ),
       ),
-    );
-    $to_return['wrapper']['description'] = array(
-      '#type' => 'markup',
       '#markup' => islandora_retrieve_description_markup($object),
     );
+
+    // Add parent collections.
     $parent_collections = islandora_get_parents_from_rels_ext($object);
     if (!empty($parent_collections)) {
-      $to_return['wrapper']['collections'] = array(
+      $to_return['collections'] = array(
         '#theme_wrappers' => array('container'),
+        '#attributes' => array(
+          'class' => array(
+            'islandora-collection-metadata-in-collections',
+            'islandora-collection-metadata',
+          ),
+        ),
       );
-      $to_return['wrapper']['collections']['heading'] = array(
+      $to_return['collections']['heading'] = array(
         '#markup' => t('<h2>In collections</h2>'),
       );
-      $to_return['wrapper']['collections']['list'] = array(
+      $to_return['collections']['list'] = array(
         '#prefix' => '<ul>',
         '#suffix' => '</ul>',
       );
       foreach ($parent_collections as $parent) {
-        $to_return['wrapper']['collections']['list'][] = array(
+        $to_return['collections']['list'][] = array(
           '#markup' => l($parent->label, "islandora/object/{$parent->id}"),
           '#prefix' => '<li>',
           '#suffix' => '</li>',
         );
       }
     }
+
+    // Preserve the 'wrapper' wrapper for legacy support.
+    $to_return['wrapper'] = array(
+      '#type' => 'item',
+      '#theme_wrappers' => array('container'),
+      '#attributes' => array(
+        'class' => array(
+          'islandora-collection-metadata',
+          'islandora-collection-metadata-markup',
+        ),
+      ),
+    );
+
+    // Add the metadata fieldset markup.
     $to_return['wrapper']['metadata'] = array(
       '#type' => 'markup',
+      '#attached' => array(
+        'js' => array(
+          'misc/form.js',
+          'misc/collapse.js',
+        ),
+      ),
       '#markup' => islandora_retrieve_metadata_markup($object),
     );
   }
   return $to_return;
 }
 
+/**
+ * Implements hook_islandora_view_object_alter().
+ */
+function islandora_basic_collection_islandora_collectionCModel_islandora_view_object_alter(&$object, &$rendered) {
+  // Get the weight order from our configuration page.
+  $weight_config = variable_get('metadata_info_table_drag_attributes', "");
+  if (isset($weight_config)) {
+    foreach ($weight_config as $key => $value) {
+      $rendered[$key]['#weight']
+        = $weight_config[$key]['weight'];
+      if ($weight_config[$key]['omit'] > 0) {
+        $rendered[$key]['#attributes']['class'][] = 'element-invisible';
+      }
+    }
+  }
+}
 
 /**
  * Implements hook_islandora_basic_collection_query_backends().

--- a/islandora_basic_collection.module
+++ b/islandora_basic_collection.module
@@ -231,14 +231,12 @@ function islandora_basic_collection_theme($existing, $type, $theme, $path) {
  * Implements hook_CMODEL_PID_islandora_view_object().
  */
 function islandora_basic_collection_islandora_collectionCModel_islandora_view_object(AbstractObject $object) {
-
   /* completely disable view of object */
   $disable = variable_get('islandora_basic_collection_disable_display_generation', FALSE);
   if ($disable) {
     $to_return = array('Collection View' => '');
   }
   else {
-
     $backend = variable_get('islandora_basic_collection_display_backend', ISLANDORA_BASIC_COLLECTION_LEGACY_BACKEND);
     $backends = module_invoke_all('islandora_basic_collection_query_backends');
     if ($backend === ISLANDORA_BASIC_COLLECTION_LEGACY_BACKEND || !isset($backends[$backend])) {
@@ -350,25 +348,18 @@ function islandora_basic_collection_islandora_collectionCModel_islandora_view_ob
       '#markup' => islandora_retrieve_metadata_markup($object),
     );
   }
-  return $to_return;
-}
 
-/**
- * Implements hook_islandora_view_object_alter().
- */
-function islandora_basic_collection_islandora_collectionCModel_islandora_view_object_alter(&$object, &$rendered) {
-  // Get the weight order from our configuration page.
-  $weight_config = variable_get('islandora_basic_collection_metadata_info_table_drag_attributes', NULL);
-  if (!is_null($weight_config)) {
-    foreach ($weight_config as $key => $value) {
-      if (isset($rendered[$key])) {
-        $rendered[$key]['#weight'] = $weight_config[$key]['weight'];
-        if ($weight_config[$key]['omit'] > 0) {
-          unset($rendered[$key]);
-        }
-      }
+  foreach (variable_get('islandora_basic_collection_metadata_info_table_drag_attributes', array()) as $key => $config) {
+    if ($config['omit']) {
+      unset($to_return[$key]);
     }
+    if (!isset($to_return[$key])) {
+      continue;
+    }
+    $to_return[$key]['#weight'] = $config['weight'];
   }
+
+  return $to_return;
 }
 
 /**

--- a/islandora_basic_collection.module
+++ b/islandora_basic_collection.module
@@ -358,13 +358,13 @@ function islandora_basic_collection_islandora_collectionCModel_islandora_view_ob
  */
 function islandora_basic_collection_islandora_collectionCModel_islandora_view_object_alter(&$object, &$rendered) {
   // Get the weight order from our configuration page.
-  $weight_config = variable_get('metadata_info_table_drag_attributes', NULL);
+  $weight_config = variable_get('islandora_basic_collection_metadata_info_table_drag_attributes', NULL);
   if (!is_null($weight_config)) {
     foreach ($weight_config as $key => $value) {
       if (isset($rendered[$key])) {
         $rendered[$key]['#weight'] = $weight_config[$key]['weight'];
         if ($weight_config[$key]['omit'] > 0) {
-          $rendered[$key]['#attributes']['class'][] = 'element-invisible';
+          unset($rendered[$key]);
         }
       }
     }

--- a/islandora_basic_collection.module
+++ b/islandora_basic_collection.module
@@ -358,8 +358,8 @@ function islandora_basic_collection_islandora_collectionCModel_islandora_view_ob
  */
 function islandora_basic_collection_islandora_collectionCModel_islandora_view_object_alter(&$object, &$rendered) {
   // Get the weight order from our configuration page.
-  $weight_config = variable_get('metadata_info_table_drag_attributes', "");
-  if (isset($weight_config)) {
+  $weight_config = variable_get('metadata_info_table_drag_attributes', NULL);
+  if (!is_null($weight_config)) {
     foreach ($weight_config as $key => $value) {
       if (isset($rendered[$key])) {
         $rendered[$key]['#weight'] = $weight_config[$key]['weight'];

--- a/theme/theme.inc
+++ b/theme/theme.inc
@@ -84,6 +84,38 @@ function template_preprocess_islandora_basic_collection_wrapper(&$variables) {
 }
 
 /**
+ * Implements hook_theme().
+ */
+function theme_islandora_basic_collection_metadata_table_drag_components($vars) {
+  $element = $vars['element'];
+  drupal_add_tabledrag('islandora_basic_collection_meta_page_element_table', 'order', 'sibling', 'item-row-weight');
+
+  $header = array(
+    'label' => t('Attribute'),
+    'textfield' => t('Description'),
+    'weight' => t('Weight'),
+    'omit' => t('Hide from display'),
+  );
+
+  $rows = array();
+  foreach (element_children($element) as $key) {
+    $row = array();
+    $row['data'] = array();
+    foreach ($header as $fieldname => $title) {
+      $row['data'][] = drupal_render($element[$key][$fieldname]);
+      $row['class'] = array('draggable');
+    }
+    $rows[] = $row;
+  }
+
+  return theme('table', array(
+    'header' => $header,
+    'rows' => $rows,
+    'attributes' => array('id' => 'islandora_basic_collection_meta_page_element_table'),
+  ));
+}
+
+/**
  * Implements template_preprocess_HOOK().
  */
 function template_preprocess_islandora_basic_collection(&$variables) {

--- a/theme/theme.inc
+++ b/theme/theme.inc
@@ -84,11 +84,22 @@ function template_preprocess_islandora_basic_collection_wrapper(&$variables) {
 }
 
 /**
- * Implements hook_theme().
+ * Returns HTML for the metadata_table_drag_components weight table.
+ *
+ * @param array $vars
+ *   An associative array containing:
+ *   - element: Table element array.
+ *   - theme_hook_original: Initial theme hook.
+ *
+ * @return string
+ *   Themed table html.
+ *
+ * @ingroup themeable
  */
 function theme_islandora_basic_collection_metadata_table_drag_components($vars) {
   $element = $vars['element'];
-  drupal_add_tabledrag('islandora_basic_collection_meta_page_element_table', 'order', 'sibling', 'item-row-weight');
+  $clean_id = drupal_html_id('islandora_basic_collection_meta_page_element_table');
+  drupal_add_tabledrag($clean_id, 'order', 'sibling', 'item-row-weight');
 
   $header = array(
     'label' => t('Attribute'),
@@ -111,7 +122,7 @@ function theme_islandora_basic_collection_metadata_table_drag_components($vars) 
   return theme('table', array(
     'header' => $header,
     'rows' => $rows,
-    'attributes' => array('id' => 'islandora_basic_collection_meta_page_element_table'),
+    'attributes' => array('id' => $clean_id),
   ));
 }
 


### PR DESCRIPTION
**JIRA Ticket**: (https://jira.duraspace.org/browse/ISLANDORA-1773)
# What does this Pull Request do?

Normalize description on collection pages driven by SOLR backend display, and exposes page components on said pages to have a configurable weight/display.
# What's new?

This pull request adds a 'Page Content Placement' table drag component to the collection solution pack configuration page. The table is made available to SOLR driven backend displays that are configured to display object metadata. To make use of this feature, the Solr driven backend display must be selected as well as the display object metadata option on the collection_solution_pack configuration page.

The table drag component allows an administrative user to configure the weight and visibility of four components:
- Fieldset Metadata
  *\* An objects metadata collection set
- Description
  *\* An objects configured metadata display description field
- Object Content
  *\* The collection page's content, such as a list or grid view (including pager and display switch)
- In Collections
  *\* A list of what collections this object (current collection) is found in.

These components can already be found on a collections page using a SOLR driven backend, however the placement of components or visibility of components has never really been configurable outside of modifying code. 

By exposing the weights and display of each of these page components individually, the configured description metadata field on SOLR driven displays can now be configured to appear as it does on the SPARQL driven collection pages. 
# How should this be tested?

To test this functionality:
- Retrieve the latest code in this pull request.
- Ensure a test collection is present, and has a configured metadata display associated with its content model (including description).
- Navigate to {SITE}/admin/islandora/solution_pack_config/basic_collection
- Select 'Solr' under 'Display Generation'
- Select 'Display object metadata' under 'Metadata display'.
- Configure page components as desired, such as its weight, or hiding from display entirely in the newly available 'Page Content Placement' drag table. 

Sample Screenshot of configuration:
![screen shot 2016-08-02 at 11 31 02 am](https://cloud.githubusercontent.com/assets/3580299/17332523/70824c3a-58a5-11e6-869c-2430af324412.png)
# Additional Notes:

Any existing documentation on the collection solution pack should be updated to include the usage of this new feature. No dependencies have been added here, and no other modifications to the code base are required.
# Interested parties

Tag  @willtp87 @Islandora/7-x-1-x-committers 
