### PR TITLE
7.x islandora 1828

### DIFF
--- a/includes/manage_collection.inc
+++ b/includes/manage_collection.inc
@@ -261,7 +261,7 @@ function islandora_basic_collection_policy_management_form(array $form, array &$
     $policy = new CollectionPolicy($object['COLLECTION_POLICY']->content);
   }
   else {
-    $policy = CollectionPolicy::emptyPolicy()->getXML();
+    $policy = CollectionPolicy::emptyPolicy();
   }
   $policy_content_models = $policy->getContentModels();
   $content_models = islandora_get_content_models();

--- a/includes/manage_collection.inc
+++ b/includes/manage_collection.inc
@@ -257,7 +257,12 @@ function islandora_basic_collection_policy_management_form(array $form, array &$
   module_load_include('inc', 'islandora', 'includes/utilities');
   drupal_add_css(drupal_get_path('module', 'islandora_basic_collection') . "/css/collection_policy_table.css");
   $form_state['collection'] = $object;
-  $policy = new CollectionPolicy($object['COLLECTION_POLICY']->content);
+  if (isset($object['COLLECTION_POLICY'])) {
+    $policy = new CollectionPolicy($object['COLLECTION_POLICY']->content);
+  }
+  else {
+    $policy = CollectionPolicy::emptyPolicy()->getXML();
+  }
   $policy_content_models = $policy->getContentModels();
   $content_models = islandora_get_content_models();
   $default_namespace = drupal_substr($object->id, 0, strpos($object->id, ":"));
@@ -328,7 +333,16 @@ function islandora_basic_collection_policy_management_form_submit(array $form, a
     $content_model = islandora_object_load($pid);
     $policy->addContentModel($pid, $properties['prompt'], $properties['namespace']);
   }
-  $collection['COLLECTION_POLICY']->content = $policy->getXML();
+  if (!isset($collection['COLLECTION_POLICY'])) {
+    $cp_ds = $collection->constructDatastream('COLLECTION_POLICY', 'M');
+    $cp_ds->mimetype = 'application/xml';
+    $cp_ds->label = 'Collection Policy';
+    $cp_ds->setContentFromString($policy->getXML());
+    $collection->ingestDatastream($cp_ds);
+  }
+  else {
+    $collection['COLLECTION_POLICY']->setContentFromString($policy->getXML());
+  }
   drupal_set_message(t('Updated collection policy'));
 }
 

--- a/islandora_basic_collection.module
+++ b/islandora_basic_collection.module
@@ -737,11 +737,6 @@ EOQ;
  * Implements hook_islandora_undeletable_datastreams().
  */
 function islandora_basic_collection_islandora_undeletable_datastreams($models) {
-  if (in_array('islandora:collectionCModel', $models)) {
-    if (variable_get('islandora_basic_collection_disable_collection_policy_delete', TRUE)) {
-      return array('COLLECTION_POLICY');
-    }
-  }
 }
 
 /**
@@ -897,14 +892,11 @@ function islandora_basic_collection_islandora_object_access($op, $object, $user)
   $result = NULL;
 
   $collection_models = islandora_basic_collection_get_collection_content_models();
-  $is_a_collection = (
-    (count(array_intersect($collection_models, $object->models)) > 0) &&
-    isset($object['COLLECTION_POLICY'])
-  );
+  $is_a_collection = count(array_intersect($collection_models, $object->models)) > 0;
 
   if (in_array($op, array_keys(islandora_basic_collection_permission()))) {
     if ($is_a_collection) {
-      if ($op == ISLANDORA_BASIC_COLLECTION_CREATE_CHILD_COLLECTION) {
+      if ($op == ISLANDORA_BASIC_COLLECTION_CREATE_CHILD_COLLECTION && isset($object['COLLECTION_POLICY'])) {
         $result = islandora_object_access(ISLANDORA_INGEST, $object, $user) && islandora_datastream_access(ISLANDORA_VIEW_OBJECTS, $object['COLLECTION_POLICY'], $user);
         if ($result) {
           $policy = new CollectionPolicy($object['COLLECTION_POLICY']->content);
@@ -913,7 +905,12 @@ function islandora_basic_collection_islandora_object_access($op, $object, $user)
         }
       }
       elseif ($op == ISLANDORA_BASIC_COLLECTION_MANAGE_COLLECTION_POLICY) {
-        $result = islandora_datastream_access(ISLANDORA_METADATA_EDIT, $object['COLLECTION_POLICY'], $user);
+        if (isset($object['COLLECTION_POLICY'])) {
+          $result = islandora_datastream_access(ISLANDORA_METADATA_EDIT, $object['COLLECTION_POLICY'], $user);
+        }
+        else {
+          $result = islandora_object_access(ISLANDORA_ADD_DS, $object, $user);
+        }
       }
       elseif ($op == ISLANDORA_BASIC_COLLECTION_MIGRATE_COLLECTION_MEMBERS) {
         // Not sure how much sense this makes... Check that we can modify the

--- a/islandora_basic_collection.module
+++ b/islandora_basic_collection.module
@@ -737,6 +737,11 @@ EOQ;
  * Implements hook_islandora_undeletable_datastreams().
  */
 function islandora_basic_collection_islandora_undeletable_datastreams($models) {
+  if (in_array('islandora:collectionCModel', $models)) {
+    if (variable_get('islandora_basic_collection_disable_collection_policy_delete', TRUE)) {
+      return array('COLLECTION_POLICY');
+    }
+  }
 }
 
 /**


### PR DESCRIPTION
**JIRA Ticket**: https://jira.duraspace.org/projects/ISLANDORA/issues/ISLANDORA-1828
# What does this Pull Request do?

Makes it so that the collection management controls that don't rely on an existing collection policy don't require an existing collection policy
# What's new?

Just the fact that the collection policy management tab shows up on the collection management interface even if no COLLECTION_POLICY datastream exists.

This also cascades to the migrate/copy objects tabs, since those relied on the same access hook and were also hard-requiring the COLLECTION_POLICY datastream.
# How should this be tested?
- Remove the COLLECTION_POLICY datastream from a collection. Note that this can't be done through the Islandora interface; you'll either have to do it through Fedora or manually create a collection object with no policy.
- Go to that collection's collection management page
- The three vertical tabs mentioned above should appear
- They should continue to function as expected
- Fill out and submit the collection policy management form
- A COLLECTION_POLICY datastream with the configured policy should be added to the collection
# Interested parties

@willtp87 and @ajstanley on the module, and @rosiel from the discussion had at committers.
