### PR TITLE
Add validation to not allow a collection to be shared/migrated to itself

### DIFF
--- a/includes/manage_collection.inc
+++ b/includes/manage_collection.inc
@@ -389,9 +389,9 @@ function islandora_basic_collection_share_children_form(array $form, array &$for
  * Form validation for share children form.
  *
  * @param array $form
- *    The Drupal form definition.
+ *   The Drupal form definition.
  * @param array $form_state
- *    The Drupal form state.
+ *   The Drupal form state.
  */
 function islandora_basic_collection_share_children_form_validate(array $form, array &$form_state) {
   if (!islandora_basic_collection_validate_form($form_state)) {
@@ -465,9 +465,9 @@ function islandora_basic_collection_migrate_children_form(array $form, array &$f
  * Form validation for migrate children form.
  *
  * @param array $form
- *    The Drupal form definition.
+ *   The Drupal form definition.
  * @param array $form_state
- *    The Drupal form state.
+ *   The Drupal form state.
  */
 function islandora_basic_collection_migrate_children_form_validate(array $form, array &$form_state) {
   if (!islandora_basic_collection_validate_form($form_state)) {
@@ -550,10 +550,10 @@ function islandora_basic_collection_delete_children_form_submit(array $form, arr
  * Ensures you don't share/migrate a collection into itself.
  *
  * @param array $form_state
- *    The Drupal form state.
+ *   The Drupal form state.
  *
  * @return bool
- *    Whether the form is valid or not.
+ *   Whether the form is valid or not.
  */
 function islandora_basic_collection_validate_form(array $form_state) {
   $new_collection = $form_state['values']['collection'];

--- a/includes/manage_collection.inc
+++ b/includes/manage_collection.inc
@@ -394,34 +394,8 @@ function islandora_basic_collection_share_children_form(array $form, array &$for
  *    The Drupal form state.
  */
 function islandora_basic_collection_share_children_form_validate(array $form, array &$form_state) {
-  $new_collection = $form_state['values']['collection'];
-  $clicked_button = end($form_state['clicked_button']['#parents']);
-  $get_pid = function($o) {
-    if (isset($o['object']['value'])) {
-      return $o['object']['value'];
-    }
-    else {
-      return '';
-    }
-  };
-
-  if ($clicked_button == 'submit_all') {
-    $collection = $form_state['collection'];
-    $page = 0;
-    do {
-      list($count, $results) = islandora_basic_collection_get_member_objects($collection, $page, 10, 'manage');
-      $results = array_map($get_pid, $results);
-      if (array_intersect($results, array($new_collection))) {
-        form_set_error('collection', t("You cannot share a collection with itself."));
-        break;
-      }
-    } while (($page++ * 10) + 10 < $count);
-  }
-  else {
-    $children = array_keys(array_filter($form_state['values']['children']));
-    if (array_intersect($children, array($new_collection))) {
-      form_set_error('collection', t("You cannot share a collection with itself."));
-    }
+  if (!islandora_basic_collection_validate_form($form_state)) {
+    form_set_error('collection', t("You cannot share a collection with itself."));
   }
 }
 
@@ -496,34 +470,8 @@ function islandora_basic_collection_migrate_children_form(array $form, array &$f
  *    The Drupal form state.
  */
 function islandora_basic_collection_migrate_children_form_validate(array $form, array &$form_state) {
-  $new_collection = $form_state['values']['collection'];
-  $clicked_button = end($form_state['clicked_button']['#parents']);
-  $get_pid = function($o) {
-    if (isset($o['object']['value'])) {
-      return $o['object']['value'];
-    }
-    else {
-      return '';
-    }
-  };
-
-  if ($clicked_button == 'submit_all') {
-    $collection = $form_state['collection'];
-    $page = 0;
-    do {
-      list($count, $results) = islandora_basic_collection_get_member_objects($collection, $page, 10, 'manage');
-      $results = array_map($get_pid, $results);
-      if (array_intersect($results, array($new_collection))) {
-        form_set_error('collection', t("You cannot migrate a collection into itself."));
-        break;
-      }
-    } while (($page++ * 10) + 10 < $count);
-  }
-  else {
-    $children = array_keys(array_filter($form_state['values']['children']));
-    if (array_intersect($children, array($new_collection))) {
-      form_set_error('collection', t("You cannot migrate a collection into itself."));
-    }
+  if (!islandora_basic_collection_validate_form($form_state)) {
+    form_set_error('collection', t("You cannot migrate a collection into itself."));
   }
 }
 
@@ -594,4 +542,47 @@ function islandora_basic_collection_delete_children_form_submit(array $form, arr
   $children = array_keys(array_filter($form_state['values']['children']));
   $batch = islandora_basic_collection_delete_children_batch($collection, $children);
   batch_set($batch);
+}
+
+/**
+ * Common form validation for share/migrate members.
+ *
+ * Ensures you don't share/migrate a collection into itself.
+ *
+ * @param array $form_state
+ *    The Drupal form state.
+ *
+ * @return bool
+ *    Whether the form is valid or not.
+ */
+function islandora_basic_collection_validate_form(array $form_state) {
+  $new_collection = $form_state['values']['collection'];
+  $clicked_button = end($form_state['clicked_button']['#parents']);
+  $get_pid = function($o) {
+    if (isset($o['object']['value'])) {
+      return $o['object']['value'];
+    }
+    else {
+      return '';
+    }
+  };
+
+  if ($clicked_button == 'submit_all') {
+    $collection = $form_state['collection'];
+    $page = 0;
+    do {
+      list($count, $results) = islandora_basic_collection_get_member_objects($collection, $page, 10, 'manage');
+      $results = array_map($get_pid, $results);
+      if (array_intersect($results, array($new_collection))) {
+        return FALSE;
+      }
+    } while (($page++ * 10) + 10 < $count);
+  }
+  else {
+    $children = array_keys(array_filter($form_state['values']['children']));
+    if (array_intersect($children, array($new_collection))) {
+      return FALSE;
+    }
+  }
+  return TRUE;
 }

--- a/includes/manage_collection.inc
+++ b/includes/manage_collection.inc
@@ -558,25 +558,19 @@ function islandora_basic_collection_delete_children_form_submit(array $form, arr
 function islandora_basic_collection_validate_form(array $form_state) {
   $new_collection = $form_state['values']['collection'];
   $clicked_button = end($form_state['clicked_button']['#parents']);
-  $get_pid = function($o) {
-    if (isset($o['object']['value'])) {
-      return $o['object']['value'];
-    }
-    else {
-      return '';
-    }
-  };
 
   if ($clicked_button == 'submit_all') {
-    $collection = $form_state['collection'];
-    $page = 0;
-    do {
-      list($count, $results) = islandora_basic_collection_get_member_objects($collection, $page, 10, 'manage');
-      $results = array_map($get_pid, $results);
-      if (array_intersect($results, array($new_collection))) {
-        return FALSE;
-      }
-    } while (($page++ * 10) + 10 < $count);
+    $source_collection = $form_state['collection'];
+    $query = <<<EOT
+PREFIX fedora-rels-ext: <info:fedora/fedora-system:def/relations-external#>
+SELECT ?object WHERE {
+?object fedora-rels-ext:isMemberOfCollection <info:fedora/{$source_collection}> .
+FILTER (sameTerm(?object, <info:fedora/{$new_collection}>))
+}
+EOT;
+    $connection = islandora_get_tuque_connection();
+    $num_results = $connection->repository->ri->countQuery($query, 'sparql');
+    return ($num_results <= 0);
   }
   else {
     $children = array_keys(array_filter($form_state['values']['children']));

--- a/includes/manage_collection.inc
+++ b/includes/manage_collection.inc
@@ -386,6 +386,46 @@ function islandora_basic_collection_share_children_form(array $form, array &$for
 }
 
 /**
+ * Form validation for share children form.
+ *
+ * @param array $form
+ *    The Drupal form definition.
+ * @param array $form_state
+ *    The Drupal form state.
+ */
+function islandora_basic_collection_share_children_form_validate(array $form, array &$form_state) {
+  $new_collection = $form_state['values']['collection'];
+  $clicked_button = end($form_state['clicked_button']['#parents']);
+  $get_pid = function($o) {
+    if (isset($o['object']['value'])) {
+      return $o['object']['value'];
+    }
+    else {
+      return '';
+    }
+  };
+
+  if ($clicked_button == 'submit_all') {
+    $collection = $form_state['collection'];
+    $page = 0;
+    do {
+      list($count, $results) = islandora_basic_collection_get_member_objects($collection, $page, 10, 'manage');
+      $results = array_map($get_pid, $results);
+      if (array_intersect($results, array($new_collection))) {
+        form_set_error('collection', t("You cannot share a collection with itself."));
+        break;
+      }
+    } while (($page++ * 10) + 10 < $count);
+  }
+  else {
+    $children = array_keys(array_filter($form_state['values']['children']));
+    if (array_intersect($children, array($new_collection))) {
+      form_set_error('collection', t("You cannot share a collection with itself."));
+    }
+  }
+}
+
+/**
  * Submit handler for the share children form.
  *
  * @param array $form
@@ -445,6 +485,46 @@ function islandora_basic_collection_migrate_children_form(array $form, array &$f
       '#value' => t('Migrate All Objects'),
     ),
   );
+}
+
+/**
+ * Form validation for migrate children form.
+ *
+ * @param array $form
+ *    The Drupal form definition.
+ * @param array $form_state
+ *    The Drupal form state.
+ */
+function islandora_basic_collection_migrate_children_form_validate(array $form, array &$form_state) {
+  $new_collection = $form_state['values']['collection'];
+  $clicked_button = end($form_state['clicked_button']['#parents']);
+  $get_pid = function($o) {
+    if (isset($o['object']['value'])) {
+      return $o['object']['value'];
+    }
+    else {
+      return '';
+    }
+  };
+
+  if ($clicked_button == 'submit_all') {
+    $collection = $form_state['collection'];
+    $page = 0;
+    do {
+      list($count, $results) = islandora_basic_collection_get_member_objects($collection, $page, 10, 'manage');
+      $results = array_map($get_pid, $results);
+      if (array_intersect($results, array($new_collection))) {
+        form_set_error('collection', t("You cannot migrate a collection into itself."));
+        break;
+      }
+    } while (($page++ * 10) + 10 < $count);
+  }
+  else {
+    $children = array_keys(array_filter($form_state['values']['children']));
+    if (array_intersect($children, array($new_collection))) {
+      form_set_error('collection', t("You cannot migrate a collection into itself."));
+    }
+  }
 }
 
 /**


### PR DESCRIPTION
**JIRA Ticket**: https://jira.duraspace.org/browse/ISLANDORA-1892

Also - https://jira.duraspace.org/browse/ISLANDORA-1775

# What does this Pull Request do?

Adds form validation to the Collection objects Share/Migrate members fieldsets in the Collection tab. (Manage -> Collection)
Checks that if any of the objects being migrated have the same PID as the destination collection. Fails if this test is TRUE.

# What's new?

You can either select some object to be migrated, or choose migrate all.

If you select to migrate/share some, it takes the array of PIDs from the form_state and does an array_intersect with an array of `array($new_collection)`. If there is any objects in the resulting array (meaning a match) we fail.

If you select to migrate/share all items, it does a loop of all the items in the collection in pages of 10. It mutates the result into an array of PIDs and performs the array_intersect (as above). If there is a match it fails, otherwise it grabs more objects until it fails or tests all children.

# How should this be tested?

1. Make 2 collections at the same level of your repository.
1. Manage the collection holding these new collections. 
1. Goto the Collections tab.
1. Choose either (eventually both) Migrate members or Share Members.
   1. Try to migrate one collection to the other. This should work.
   1. Try to migrate one collection to itself. This should **not** work.


Example:
* Does this change require documentation to be updated? no
* Does this change add any new dependencies?  no
* Does this change require any other modifications to be made to the repository (ie. Regeneration activity, etc.)? no
* Could this change impact execution of existing code? no

# Interested parties
@bondjimbond and @Islandora/7-x-1-x-committers
