### PR TITLE
Remove second maintainer for release 7.x-1.9

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,6 @@ Having problems or solved a problem? Check out the Islandora google groups for a
 Current maintainers:
 
 * [William Panting](https://github.com/willtp87)
-* [Alan Stanley](https://github.com/ajstanley)
 
 ## Development
 


### PR DESCRIPTION
**JIRA Ticket**: n/a

# What does this Pull Request do?

This PR removes Alan Stanley as second maintainer in accordance with the [release spreadsheet](https://docs.google.com/spreadsheets/d/1PRv2Xo-sNE_sDJHUT5OvTXmNiSHnkdJgwo7VsFkIUgY/edit#gid=1465332831).

# What's new?

This SP now only has one maintainer.

# How should this be tested?

N/A

# Additional Notes:

N/A

# Interested parties

@ajstanley (former maintainer), @willtp87 (remaining maintainer)
