### PR TITLE
Fixing bad link in readme.

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Set the default number of collection objects per page, view style, and configura
 
 ## Documentation
 
-Further documentation for this module is available at [our wiki](https://wiki.duraspace.org/display/ISLANDORA/Basic+Collection+Solution+Pack).
+Further documentation for this module is available at [our wiki](https://wiki.duraspace.org/display/ISLANDORA/Collection+Solution+Pack).
 
 ## Troubleshooting/Issues
 


### PR DESCRIPTION
# What does this Pull Request do?

Updates the wiki link in the readme to point to the right page in our Confluence wiki. The old link is dead.

# How should this be tested?

Check the link link, verify it's the right page, Bob's yer uncle.

# Interested parties
@willtp87 (component manager), @DonRichards (docs manager) or @DiegoPino (release manager)
