### PR TITLE
Ensure the TN does not exist before attempting to create a new one.

### DIFF
--- a/islandora_basic_collection.module
+++ b/islandora_basic_collection.module
@@ -951,13 +951,14 @@ function islandora_basic_collection_islandora_collectioncmodel_islandora_ingest_
  * Implements hook_CMODEL_PID_islandora_object_ingested().
  */
 function islandora_basic_collection_islandora_collectioncmodel_islandora_object_ingested(AbstractObject $fedora_object) {
-
-  // Add TN datastream.
-  $thumbnail_datastream = $fedora_object->constructDatastream('TN');
-  $thumbnail_datastream->setContentFromFile(drupal_get_path('module', 'islandora_basic_collection') . '/images/folder.png', FALSE);
-  $thumbnail_datastream->label = 'Thumbnail';
-  $thumbnail_datastream->mimetype = 'image/png';
-  $fedora_object->ingestDatastream($thumbnail_datastream);
+  if (!isset($fedora_object['TN'])) {
+    // Add TN datastream.
+    $thumbnail_datastream = $fedora_object->constructDatastream('TN');
+    $thumbnail_datastream->setContentFromFile(drupal_get_path('module', 'islandora_basic_collection') . '/images/folder.png', FALSE);
+    $thumbnail_datastream->label = 'Thumbnail';
+    $thumbnail_datastream->mimetype = 'image/png';
+    $fedora_object->ingestDatastream($thumbnail_datastream);
+  }
 }
 
 /**


### PR DESCRIPTION
**JIRA Ticket**: https://jira.duraspace.org/browse/ISLANDORA-1995

# What does this Pull Request do?
Ensures a datastream does not exist before attempting to create it.

# What's new?
An `isset` check.

# How should this be tested?
Ingest a collection that does not have a thumbnail, it gets a thumbnail.
Re-ingest a collection that defines a TN from the required objects solution packs page (admin/islandora/solution_pack_config/solution_packs)
It does not attempt to get another TN.

# Additional Notes:
Relates to https://github.com/Islandora/tuque/pull/157 and https://github.com/Islandora/islandora/pull/678.

# Interested parties
@dannylamb, @DiegoPino, @jonathangreen 
