### PR TITLE
Add PIDs to labels in Share and Migrate options

### DIFF
--- a/includes/utilities.inc
+++ b/includes/utilities.inc
@@ -102,6 +102,7 @@ function islandora_basic_collection_get_children_select_table_form_element(Abstr
   foreach ($results as $result) {
     $pid = $result['object']['value'];
     $label = empty($result['title']['value']) ? t('Untitled') : filter_xss($result['title']['value']);
+    $label = $label . " (" . $pid . ")";
     $owner = empty($result['owner']['value']) ? t('Unowned') : filter_xss($result['owner']['value']);
     $date_modified = empty($result['date_modified']['value']) ? t('Unknown') : filter_xss($result['date_modified']['value']);
     $rows[$pid] = array(

--- a/islandora_basic_collection.module
+++ b/islandora_basic_collection.module
@@ -726,7 +726,7 @@ EOQ;
     if (islandora_namespace_accessible($pid)) {
       $collections[$pid] = array(
         'pid' => $pid,
-        'label' => $result['label']['value'],
+        'label' => $result['label']['value'] . " (" . $pid . ")",
       );
     }
   }


### PR DESCRIPTION
**JIRA Ticket**: (https://jira.duraspace.org/browse/ISLANDORA-1878)

# What does this Pull Request do?

Adds PIDs to object and collection labels on the Share and Migrate screens. Allows site admins to precisely identify which objects are being migrated to which collection, in cases where labels are similar or identical.

# How should this be tested?

* Manage a collection
* Go to the Collection tab, and look at the Share and Migrate screens
* Verify that child objects have PIDs in their labels; verify that the Share and Migrate options given have PIDs next to their labels
* Verify that PIDs listed correspond correctly to the labels shown

# Additional Notes:

Nothing more than a labeling change; shouldn't have any adverse effects.

# Interested parties
@Islandora/7-x-1-x-committers
