### PR TITLE
ISLANDORA-1986 Use namespace restrictions in autocomplete.

### DIFF
--- a/includes/utilities.inc
+++ b/includes/utilities.inc
@@ -209,6 +209,7 @@ function islandora_basic_collection_remove_from_collection(AbstractObject $membe
  *   Returns a json array of matching collections.
  */
 function islandora_basic_collection_get_collections_filtered($search_value) {
+  module_load_include('inc', 'islandora', 'includes/utilities');
   $tuque = islandora_get_tuque_connection();
   $sparql_query = <<<EOQ
 SELECT ?pid ?label
@@ -221,10 +222,13 @@ EOQ;
   $results = $tuque->repository->ri->sparqlQuery($sparql_query);
   $return = array();
   foreach ($results as $objects) {
-    $return[$objects['pid']['value']] = t('@label (@pid)', array(
-      '@label' => $objects['label']['value'],
-      '@pid' => $objects['pid']['value'],
-    ));
+    $pid = $objects['pid']['value'];
+    if (islandora_namespace_accessible($pid)) {
+      $return[$pid] = t('@label (@pid)', array(
+        '@label' => $objects['label']['value'],
+        '@pid' => $pid,
+      ));
+    }
   }
   drupal_json_output($return);
 }


### PR DESCRIPTION
**JIRA Ticket**: https://jira.duraspace.org/browse/ISLANDORA-1986


# What does this Pull Request do?

Use namespace restrictions when doing the collection autocomplete. This autocomplete is used when looking at an individual object and using the "Migrate this Object to another collection" "Share this Object with another collection" links. 

# What's new?
Check for islandora_namespace_accessible() before returning collection options.

# How should this be tested?

* To reproduce: (see Jira ticket for a nice screenshot) Create a collection with a pid in a special (non-"islandora") namespace, and configure your site to use namespace restrictions and do not include this namespace. Navigate to an object > Manage > Share this Object with another collection. Start typing the name of your forbidden collection. 
* After this pull request: It does not appear any more.

# Additional Notes:
* Does this change require documentation to be updated?  No.
* Does this change add any new dependencies?  No. 
* Does this change require any other modifications to be made to the repository (ie. Regeneration activity, etc.)? No. 
* Could this change impact execution of existing code? No.

# Interested parties
Tag @bondjimbond and @Islandora/7-x-1-x-committers 