### PR TITLE
Fix failing tests by removing undocumented dependency on xml_form_builder

### DIFF
--- a/tests/islandora_basic_collection_ingest_purge.test
+++ b/tests/islandora_basic_collection_ingest_purge.test
@@ -41,7 +41,6 @@ class IslandoraBasicCollectionIngestTestCase extends IslandoraCollectionWebTestC
     $this->drupalLogin($user);
 
     // Add a collection.
-    $label = $this->randomName(16);
     $pid = 'islandora:' . $this->randomName();
     $this->drupalPost('islandora/object/islandora:root/manage/overview/ingest', array('pid' => $pid), 'Ingest');
 

--- a/tests/islandora_basic_collection_ingest_purge.test
+++ b/tests/islandora_basic_collection_ingest_purge.test
@@ -29,7 +29,6 @@ class IslandoraBasicCollectionIngestTestCase extends IslandoraCollectionWebTestC
     parent::setUp(array(
       'islandora',
       'islandora_basic_collection',
-      'xml_form_builder',
     ));
   }
 
@@ -44,8 +43,7 @@ class IslandoraBasicCollectionIngestTestCase extends IslandoraCollectionWebTestC
     // Add a collection.
     $label = $this->randomName(16);
     $pid = 'islandora:' . $this->randomName();
-    $this->drupalPost('islandora/object/islandora:root/manage/overview/ingest', array('pid' => $pid), 'Next');
-    $this->drupalPost(NULL, array('titleInfo[title]' => $label), 'Ingest');
+    $this->drupalPost('islandora/object/islandora:root/manage/overview/ingest', array('pid' => $pid), 'Ingest');
 
     // Check if we made a collection correctly.
     $object = islandora_object_load($pid);


### PR DESCRIPTION
# JIRA Ticket

https://jira.duraspace.org/browse/ISLANDORA-2188

# What does this Pull Request do?

After downloading and installing the Islandora Collection Solution Pack module and running the tests against the latest branches of islandora, there were 5 failing tests. This ended up being due to an assumption in one of the test cases that the xml_form_builder module and all of its dependencies were downloaded, though the collection solution pack does not declare a dependency on these modules.

# What's new?
* Removes the undocumented dependency on xml_form_builder. If the XML Form Builder module modifies a form, the test for the modified form belongs in that module's tests.

# How should this be tested?

On a fresh Drupal install follow the standard steps for enabling the Islandora and islandora_solution_pack_collection modules. The problem addressed by this ticket can be reproduced by ensuring that the XML Form Builder module is not downloaded on the site instance being tested.

With SimpleTest enabled, go to Admin -> Configuration -> Development -> Testing and run the tests for the Islandora Basic Collection.

[Test result before| drupal.test.pdf](https://github.com/Islandora/islandora_solution_pack_collection/files/1880110/Test.result.before.drupal.test.pdf)

### Before: 
![screen shot 2018-04-05 at 10 12 03 am](https://user-images.githubusercontent.com/82412/38367963-6aa41a86-38ba-11e8-85f0-95be6c93fc86.png)

### After
![screen shot 2018-04-05 at 10 14 24 am](https://user-images.githubusercontent.com/82412/38367964-6acb31c0-38ba-11e8-8eb8-00592b5331ce.png)


# Interested parties
@Islandora/7-x-1-x-committers