### PR TITLE
ISLANDORA-2298 - Migrating orphaned objects errors out

### DIFF
--- a/includes/migrate.form.inc
+++ b/includes/migrate.form.inc
@@ -76,8 +76,7 @@ function islandora_basic_collection_migrate_item_form_submit($form, &$form_state
   $new_collection = islandora_object_load($form_state['values']['new_collection_name']);
   $current_parents = islandora_basic_collection_get_parent_pids($object);
   if ($object && $new_collection) {
-    foreach ($current_parents as $parents) {
-      $parent = islandora_object_load($parents);
+    foreach ($current_parents as $parent) {
       islandora_basic_collection_remove_from_collection($object, $parent);
     }
     islandora_basic_collection_add_to_collection($object, $new_collection);
@@ -85,7 +84,5 @@ function islandora_basic_collection_migrate_item_form_submit($form, &$form_state
                  '@object' => $object->label,
                  '@collection' => $new_collection->label));
     drupal_set_message($message);
-
   }
-
 }

--- a/includes/utilities.inc
+++ b/includes/utilities.inc
@@ -198,7 +198,7 @@ function islandora_basic_collection_add_to_collection(AbstractObject $new_member
  *   The AbstractObject or string PID of the collection to remove object from.
  */
 function islandora_basic_collection_remove_from_collection(AbstractObject $member, $collection) {
-  if ($member instanceof AbstractObject) {
+  if ($collection instanceof AbstractObject) {
     $collection = $collection->id;
   }
 

--- a/includes/utilities.inc
+++ b/includes/utilities.inc
@@ -194,12 +194,16 @@ function islandora_basic_collection_add_to_collection(AbstractObject $new_member
  *
  * @param AbstractObject $member
  *   The object to remove.
- * @param AbstractObject $collection
- *   The collection object to remove from.
+ * @param mixed $collection
+ *   The AbstractObject or string PID of the collection to remove object from.
  */
-function islandora_basic_collection_remove_from_collection(AbstractObject $member, AbstractObject $collection) {
-  $member->relationships->remove(FEDORA_RELS_EXT_URI, 'isMemberOfCollection', $collection->id);
-  $member->relationships->remove(FEDORA_RELS_EXT_URI, 'isMemberOf', $collection->id);
+function islandora_basic_collection_remove_from_collection(AbstractObject $member, $collection) {
+  if ($member instanceof AbstractObject) {
+    $collection = $collection->id;
+  }
+
+  $member->relationships->remove(FEDORA_RELS_EXT_URI, 'isMemberOfCollection', $collection);
+  $member->relationships->remove(FEDORA_RELS_EXT_URI, 'isMemberOf', $collection);
 }
 
 /**


### PR DESCRIPTION
## JIRA Ticket

https://jira.duraspace.org/browse/ISLANDORA-2298

## What does this Pull Request do?

If an object is orphaned, it cannot be moved to another collection, as the collection solution pack tries to load the object before removing the relationship. This means we can't un-orphan objects through the UI.

## What's new?

Changed the function signature of `islandora_basic_collection_remove_from_collection`  to take a PID as well as a `AbstractObject`, so that we can remove relationships to orphaned objects. This should be backwards compatible as `islandora_basic_collection_remove_from_collection` can still take an `AbstractObject` as before.

## How should this be tested?

- Create an orphaned object
- Go into manage and try 'migrate object to another collection'
- Try to move to existing collection

Before the patch this should fail. Should work afterwords.

## Interested parties
@willtp87 @Islandora/7-x-1-x-committers