### PR TITLE
Remove exclusion of Collection CModel for migrate and share options

### DIFF
--- a/includes/migrate.form.inc
+++ b/includes/migrate.form.inc
@@ -46,8 +46,7 @@ function islandora_basic_collection_migrate_item_form($form, &$form_state, $isla
 function islandora_basic_collection_migrate_item_form_validate($form, &$form_state) {
   $new_collection = islandora_object_load($form_state['values']['new_collection_name']);
   $collection_models = islandora_basic_collection_get_collection_content_models();
-  $object = islandora_object_load($form_state['basic_collection_migrate']);
-  if ($object->id == $new_collection->id) {
+  if ($form_state['values']['new_collection_name'] == $form_state['basic_collection_migrate']) {
     form_set_error('new_collection_name', t('Collections may not be children of themselves.'));
   }
   $is_a_collection = FALSE;

--- a/includes/migrate.form.inc
+++ b/includes/migrate.form.inc
@@ -47,6 +47,9 @@ function islandora_basic_collection_migrate_item_form_validate($form, &$form_sta
   $new_collection = islandora_object_load($form_state['values']['new_collection_name']);
   $collection_models = islandora_basic_collection_get_collection_content_models();
   $object = islandora_object_load($form_state['basic_collection_migrate']);
+  if ($object->id == $new_collection->id) {
+    form_set_error('new_collection_name', t('Collections may not be children of themselves.'));
+  }
   $is_a_collection = FALSE;
   if (is_object($new_collection)) {
     $is_a_collection = (
@@ -56,9 +59,6 @@ function islandora_basic_collection_migrate_item_form_validate($form, &$form_sta
   }
   if (!$is_a_collection) {
     form_set_error('new_collection_name', t('Not a valid collection'));
-  }
-  if ($object === $new_collection) {
-    form_set_error('new_collection_name', t('Collections may not be children of themselves.'));
   }
   $has_ingest_permissions = islandora_object_access(ISLANDORA_INGEST, $new_collection);
   if (!$has_ingest_permissions) {

--- a/includes/migrate.form.inc
+++ b/includes/migrate.form.inc
@@ -76,6 +76,11 @@ function islandora_basic_collection_migrate_item_form_submit($form, &$form_state
   $new_collection = islandora_object_load($form_state['values']['new_collection_name']);
   $current_parents = islandora_basic_collection_get_parent_pids($object);
   if ($object && $new_collection) {
+    if ($object === $new_collection) {
+      drupal_set_message(t('Migration aborted. A collection may not be a child of itself.'), 'error');
+      RETURN;
+    }
+
     foreach ($current_parents as $parents) {
       $parent = islandora_object_load($parents);
       islandora_basic_collection_remove_from_collection($object, $parent);

--- a/includes/migrate.form.inc
+++ b/includes/migrate.form.inc
@@ -46,6 +46,7 @@ function islandora_basic_collection_migrate_item_form($form, &$form_state, $isla
 function islandora_basic_collection_migrate_item_form_validate($form, &$form_state) {
   $new_collection = islandora_object_load($form_state['values']['new_collection_name']);
   $collection_models = islandora_basic_collection_get_collection_content_models();
+  $object = islandora_object_load($form_state['basic_collection_migrate']);
   $is_a_collection = FALSE;
   if (is_object($new_collection)) {
     $is_a_collection = (
@@ -55,6 +56,9 @@ function islandora_basic_collection_migrate_item_form_validate($form, &$form_sta
   }
   if (!$is_a_collection) {
     form_set_error('new_collection_name', t('Not a valid collection'));
+  }
+  if ($object === $new_collection) {
+    form_set_error('new_collection_name', t('Collections may not be children of themselves.'));
   }
   $has_ingest_permissions = islandora_object_access(ISLANDORA_INGEST, $new_collection);
   if (!$has_ingest_permissions) {
@@ -76,11 +80,11 @@ function islandora_basic_collection_migrate_item_form_submit($form, &$form_state
   $new_collection = islandora_object_load($form_state['values']['new_collection_name']);
   $current_parents = islandora_basic_collection_get_parent_pids($object);
   if ($object && $new_collection) {
-    if ($object === $new_collection) {
+/*    if ($object === $new_collection) {
       drupal_set_message(t('Migration aborted. A collection may not be a child of itself.'), 'error');
       RETURN;
     }
-
+*/
     foreach ($current_parents as $parents) {
       $parent = islandora_object_load($parents);
       islandora_basic_collection_remove_from_collection($object, $parent);

--- a/includes/migrate.form.inc
+++ b/includes/migrate.form.inc
@@ -81,8 +81,7 @@ function islandora_basic_collection_migrate_item_form_submit($form, &$form_state
   $current_parents = islandora_basic_collection_get_parent_pids($object);
   if ($object && $new_collection) {
     foreach ($current_parents as $parents) {
-      $parent = islandora_object_load($parents);
-      islandora_basic_collection_remove_from_collection($object, $parent);
+      islandora_basic_collection_remove_from_collection($object, $parents);
     }
     islandora_basic_collection_add_to_collection($object, $new_collection);
     $message = t('The object @object has been added to @collection', array(

--- a/includes/migrate.form.inc
+++ b/includes/migrate.form.inc
@@ -80,11 +80,6 @@ function islandora_basic_collection_migrate_item_form_submit($form, &$form_state
   $new_collection = islandora_object_load($form_state['values']['new_collection_name']);
   $current_parents = islandora_basic_collection_get_parent_pids($object);
   if ($object && $new_collection) {
-/*    if ($object === $new_collection) {
-      drupal_set_message(t('Migration aborted. A collection may not be a child of itself.'), 'error');
-      RETURN;
-    }
-*/
     foreach ($current_parents as $parents) {
       $parent = islandora_object_load($parents);
       islandora_basic_collection_remove_from_collection($object, $parent);

--- a/includes/migrate.form.inc
+++ b/includes/migrate.form.inc
@@ -79,8 +79,8 @@ function islandora_basic_collection_migrate_item_form_submit($form, &$form_state
   $new_collection = islandora_object_load($form_state['values']['new_collection_name']);
   $current_parents = islandora_basic_collection_get_parent_pids($object);
   if ($object && $new_collection) {
-    foreach ($current_parents as $parents) {
-      islandora_basic_collection_remove_from_collection($object, $parents);
+    foreach ($current_parents as $parent) {
+      islandora_basic_collection_remove_from_collection($object, $parent);
     }
     islandora_basic_collection_add_to_collection($object, $new_collection);
     $message = t('The object @object has been added to @collection', array(

--- a/includes/share.form.inc
+++ b/includes/share.form.inc
@@ -46,15 +46,15 @@ function islandora_basic_collection_share_item_form_validate($form, &$form_state
   $new_collection = islandora_object_load($form_state['values']['new_collection_name']);
   $collection_models = islandora_basic_collection_get_collection_content_models();
   $object = islandora_object_load($form_state['basic_collection_share']);
+  if ($object->id == $new_collection->id) {
+    form_set_error('new_collection_name', t('Collections may not be children of themselves.'));
+  }
   $is_a_collection = FALSE;
   if (is_object($new_collection)) {
     $is_a_collection = (
       (count(array_intersect($collection_models, $new_collection->models)) > 0) &&
       isset($new_collection['COLLECTION_POLICY'])
     );
-  }
-  if ($object === $new_collection) {
-    form_set_error('new_collection_name', t('Collections may not be children of themselves.'));
   }
   if (!$is_a_collection) {
     form_set_error('new_collection_name', t('Not a valid collection'));

--- a/includes/share.form.inc
+++ b/includes/share.form.inc
@@ -45,12 +45,16 @@ function islandora_basic_collection_share_item_form($form, &$form_state, $island
 function islandora_basic_collection_share_item_form_validate($form, &$form_state) {
   $new_collection = islandora_object_load($form_state['values']['new_collection_name']);
   $collection_models = islandora_basic_collection_get_collection_content_models();
+  $object = islandora_object_load($form_state['basic_collection_share']);
   $is_a_collection = FALSE;
   if (is_object($new_collection)) {
     $is_a_collection = (
       (count(array_intersect($collection_models, $new_collection->models)) > 0) &&
       isset($new_collection['COLLECTION_POLICY'])
     );
+  }
+  if ($object === $new_collection) {
+    form_set_error('new_collection_name', t('Collections may not be children of themselves.'));
   }
   if (!$is_a_collection) {
     form_set_error('new_collection_name', t('Not a valid collection'));
@@ -75,11 +79,6 @@ function islandora_basic_collection_share_item_form_submit($form, &$form_state) 
   $new_collection = islandora_object_load($form_state['values']['new_collection_name']);
 
   if ($object && $new_collection) {
-    if ($object === $new_collection) {
-      drupal_set_message(t('Sharing aborted. A collection may not be a child of itself.'), 'error');
-      RETURN;
-    }
-
     islandora_basic_collection_add_to_collection($object, $new_collection);
     $message = t('The object @object has been added to @collection', array(
                  '@object' => $object->label,

--- a/includes/share.form.inc
+++ b/includes/share.form.inc
@@ -75,6 +75,11 @@ function islandora_basic_collection_share_item_form_submit($form, &$form_state) 
   $new_collection = islandora_object_load($form_state['values']['new_collection_name']);
 
   if ($object && $new_collection) {
+    if ($object === $new_collection) {
+      drupal_set_message(t('Sharing aborted. A collection may not be a child of itself.'), 'error');
+      RETURN;
+    }
+
     islandora_basic_collection_add_to_collection($object, $new_collection);
     $message = t('The object @object has been added to @collection', array(
                  '@object' => $object->label,

--- a/includes/share.form.inc
+++ b/includes/share.form.inc
@@ -45,8 +45,7 @@ function islandora_basic_collection_share_item_form($form, &$form_state, $island
 function islandora_basic_collection_share_item_form_validate($form, &$form_state) {
   $new_collection = islandora_object_load($form_state['values']['new_collection_name']);
   $collection_models = islandora_basic_collection_get_collection_content_models();
-  $object = islandora_object_load($form_state['basic_collection_share']);
-  if ($object->id == $new_collection->id) {
+  if ($form_state['values']['new_collection_name'] == $form_state['basic_collection_share']) {
     form_set_error('new_collection_name', t('Collections may not be children of themselves.'));
   }
   $is_a_collection = FALSE;

--- a/islandora_basic_collection.module
+++ b/islandora_basic_collection.module
@@ -128,7 +128,11 @@ function islandora_basic_collection_share_migrate_access(AbstractObject $object)
     (count(array_intersect($collection_models, $object->models)) > 0) &&
     isset($object['COLLECTION_POLICY'])
   );
-
+  if ($is_a_collection) {
+    if($object->id == "islandora:root") {
+      return FALSE;
+    }
+  }
   return islandora_object_access(ISLANDORA_MANAGE_PROPERTIES, $object);
 }
 

--- a/islandora_basic_collection.module
+++ b/islandora_basic_collection.module
@@ -83,7 +83,7 @@ function islandora_basic_collection_menu() {
 }
 
 /**
- * Implements hook_menu_local_tasks_alter(). Move 'Add an Object' link to the top using 'weight'.
+ * Implements hook_menu_local_tasks_alter(). Moves 'Add an Object' to top.
  */
 function islandora_basic_collection_menu_local_tasks_alter(&$data, $router_item, $root_path) {
   if ($root_path == 'islandora/object/%/manage' && isset($data['actions']['output'])) {

--- a/islandora_basic_collection.module
+++ b/islandora_basic_collection.module
@@ -24,6 +24,7 @@ function islandora_basic_collection_menu() {
     'file' => 'includes/ingest.form.inc',
     'access callback' => 'islandora_basic_collection_ingest_access',
     'access arguments' => array(2),
+    'weight' => -1,
   );
   return array(
     'admin/islandora/solution_pack_config/basic_collection' => array(
@@ -80,6 +81,20 @@ function islandora_basic_collection_menu() {
     ),
   );
 }
+
+/**
+ * Implements hook_menu_local_tasks_alter().
+ * Reorders the collection management links to move 'Add an Object' to the top using 'weight'.
+ */
+ function islandora_basic_collection_menu_local_tasks_alter(&$data, $router_item, $root_path) {
+  if ($root_path == 'islandora/object/%/manage' && isset($data['actions']['output'])) {
+    foreach ($data['actions']['output'] as &$action) {
+      if (isset($action['#link']['weight'])) {
+        $action['#weight'] = $action['#link']['weight'];
+      }
+    }
+  }
+} 
 
 /**
  * Access callback for ingest.

--- a/islandora_basic_collection.module
+++ b/islandora_basic_collection.module
@@ -129,9 +129,6 @@ function islandora_basic_collection_share_migrate_access(AbstractObject $object)
     isset($object['COLLECTION_POLICY'])
   );
 
-  if ($is_a_collection) {
-    return FALSE;
-  }
   return islandora_object_access(ISLANDORA_MANAGE_PROPERTIES, $object);
 }
 

--- a/islandora_basic_collection.module
+++ b/islandora_basic_collection.module
@@ -83,10 +83,9 @@ function islandora_basic_collection_menu() {
 }
 
 /**
- * Implements hook_menu_local_tasks_alter().
- * Reorders the collection management links to move 'Add an Object' to the top using 'weight'.
+ * Implements hook_menu_local_tasks_alter(). Move 'Add an Object' link to the top using 'weight'.
  */
- function islandora_basic_collection_menu_local_tasks_alter(&$data, $router_item, $root_path) {
+function islandora_basic_collection_menu_local_tasks_alter(&$data, $router_item, $root_path) {
   if ($root_path == 'islandora/object/%/manage' && isset($data['actions']['output'])) {
     foreach ($data['actions']['output'] as &$action) {
       if (isset($action['#link']['weight'])) {
@@ -94,7 +93,7 @@ function islandora_basic_collection_menu() {
       }
     }
   }
-} 
+}
 
 /**
  * Access callback for ingest.

--- a/islandora_basic_collection.module
+++ b/islandora_basic_collection.module
@@ -129,7 +129,7 @@ function islandora_basic_collection_share_migrate_access(AbstractObject $object)
     isset($object['COLLECTION_POLICY'])
   );
   if ($is_a_collection) {
-    if($object->id == "islandora:root") {
+    if ($object->id == "islandora:root") {
       return FALSE;
     }
   }

--- a/islandora_basic_collection.module
+++ b/islandora_basic_collection.module
@@ -83,7 +83,9 @@ function islandora_basic_collection_menu() {
 }
 
 /**
- * Implements hook_menu_local_tasks_alter(). Moves 'Add an Object' to top.
+ * Implements hook_menu_local_tasks_alter().
+ *
+ * Moves 'Add an Object' link to top using 'weight'.
  */
 function islandora_basic_collection_menu_local_tasks_alter(&$data, $router_item, $root_path) {
   if ($root_path == 'islandora/object/%/manage' && isset($data['actions']['output'])) {


### PR DESCRIPTION
**JIRA Ticket**: https://jira.duraspace.org/browse/ISLANDORA-2311

# What does this Pull Request do?

Provides the Share and Migrate options on Collection management screens, which had previously been excluded.

# What's new?
Removes the code that excludes Collection objects from getting the Share and Migrate options on their Manage screens.

# How should this be tested?

* Manage a collection and observe the options presented (just "Add an object to this collection")
* Check out this branch and repeat
* Observe Share and Migrate options now present
* Check non-Collection objects to make sure nothing weird has happened

# Interested parties
@Islandora/7-x-1-x-committers
