### PR TITLE
ISLANDORA-2382 - Update Genre section in XML form

### DIFF
--- a/islandora_basic_collection.module
+++ b/islandora_basic_collection.module
@@ -425,6 +425,7 @@ function islandora_basic_collection_xml_form_builder_form_associations() {
         'titleInfo', 'title',
       ),
       'transform' => 'mods_to_dc.xsl',
+      'self_transform' => 'islandora_cleanup_mods_extended.xsl',
       'template' => FALSE,
     ),
   );

--- a/xml/islandora_basic_collection_form_mods.xml
+++ b/xml/islandora_basic_collection_form_mods.xml
@@ -377,7 +377,7 @@ e.g. Creator, Donor, etc.</description>
               <collapsed>FALSE</collapsed>
               <collapsible>FALSE</collapsible>
               <default_value>NULL</default_value>
-              <description>The authoritative source of your genre term.</description>
+              <description>The authoritative source of your genre term (e.g. marcgt, aat, lctgm).</description>
               <disabled>FALSE</disabled>
               <executes_submit_callback>FALSE</executes_submit_callback>
               <multiple>FALSE</multiple>

--- a/xml/islandora_basic_collection_form_mods.xml
+++ b/xml/islandora_basic_collection_form_mods.xml
@@ -336,6 +336,7 @@ e.g. Creator, Donor, etc.</description>
               <access>TRUE</access>
               <collapsed>FALSE</collapsed>
               <collapsible>FALSE</collapsible>
+              <default_value>lctgm</default_value>
               <description>A term that best describes the genre of the object. Terms should be taken from a controlled vocabulary such as: &lt;a href="https://www.loc.gov/standards/valuelist/marcgt.html" target="_blank"&gt;MARC Genre Terms (marcgt)&lt;/a&gt;, the &lt;a href="http://www.loc.gov/pictures/collection/tgm/" target="_blank"&gt;Thesaurus for Graphic Materials (lctgm)&lt;/a&gt;, or the &lt;a href="http://www.getty.edu/research/tools/vocabularies/aat/" target="_blank"&gt;Art and Architecture Thesaurus (aat)&lt;/a&gt;.</description>
               <disabled>FALSE</disabled>
               <executes_submit_callback>FALSE</executes_submit_callback>

--- a/xml/islandora_basic_collection_form_mods.xml
+++ b/xml/islandora_basic_collection_form_mods.xml
@@ -316,42 +316,100 @@ e.g. Creator, Donor, etc.</description>
         </properties>
         <children/>
       </element>
-      <element name="genre">
+      <element name="genreSet">
         <properties>
-          <type>textfield</type>
+          <type>fieldset</type>
           <access>TRUE</access>
           <collapsed>FALSE</collapsed>
           <collapsible>FALSE</collapsible>
-          <description>A excellent source for genre terms is the Thesaurus for Graphic Materials from the Library of Congress &lt;/br&gt;
-http://www.loc.gov/pictures/collection/tgm/</description>
           <disabled>FALSE</disabled>
           <executes_submit_callback>FALSE</executes_submit_callback>
           <multiple>FALSE</multiple>
           <required>FALSE</required>
           <resizable>FALSE</resizable>
-          <title>Genre</title>
           <tree>TRUE</tree>
-          <actions>
-            <create>
-              <path>self::node()</path>
-              <context>parent</context>
-              <schema/>
-              <type>xml</type>
-              <prefix>NULL</prefix>
-              <value>&lt;genre authority="lctgm"&gt;%value%&lt;/genre&gt;</value>
-            </create>
-            <read>
-              <path>mods:genre</path>
-              <context>parent</context>
-            </read>
-            <update>
-              <path>self::node()</path>
-              <context>self</context>
-            </update>
-            <delete>NULL</delete>
-          </actions>
         </properties>
-        <children/>
+        <children>
+          <element name="genre">
+            <properties>
+              <type>textfield</type>
+              <access>TRUE</access>
+              <collapsed>FALSE</collapsed>
+              <collapsible>FALSE</collapsible>
+              <description>A term that best describes the genre of the object. Terms should be taken from a controlled vocabulary such as: &lt;a href="https://www.loc.gov/standards/valuelist/marcgt.html" target="_blank"&gt;MARC Genre Terms (marcgt)&lt;/a&gt;, the &lt;a href="http://www.loc.gov/pictures/collection/tgm/" target="_blank"&gt;Thesaurus for Graphic Materials (lctgm)&lt;/a&gt;, or the &lt;a href="http://www.getty.edu/research/tools/vocabularies/aat/" target="_blank"&gt;Art and Architecture Thesaurus (aat)&lt;/a&gt;.</description>
+              <disabled>FALSE</disabled>
+              <executes_submit_callback>FALSE</executes_submit_callback>
+              <multiple>FALSE</multiple>
+              <required>FALSE</required>
+              <resizable>FALSE</resizable>
+              <title>Genre</title>
+              <tree>TRUE</tree>
+              <actions>
+                <create>
+                  <path>self::node()</path>
+                  <context>parent</context>
+                  <schema/>
+                  <type>element</type>
+                  <prefix>NULL</prefix>
+                  <value>genre</value>
+                </create>
+                <read>
+                  <path>mods:genre</path>
+                  <context>parent</context>
+                </read>
+                <update>
+                  <path>self::node()</path>
+                  <context>self</context>
+                </update>
+                <delete>
+                  <path>self::node()</path>
+                  <context>self</context>
+                </delete>
+              </actions>
+            </properties>
+            <children/>
+          </element>
+          <element name="genreAuthority">
+            <properties>
+              <type>textfield</type>
+              <access>TRUE</access>
+              <collapsed>FALSE</collapsed>
+              <collapsible>FALSE</collapsible>
+              <default_value>NULL</default_value>
+              <description>The authoritative source of your genre term.</description>
+              <disabled>FALSE</disabled>
+              <executes_submit_callback>FALSE</executes_submit_callback>
+              <multiple>FALSE</multiple>
+              <required>FALSE</required>
+              <resizable>FALSE</resizable>
+              <title>Genre vocabulary</title>
+              <tree>TRUE</tree>
+              <actions>
+                <create>
+                  <path>self::node()/mods:genre</path>
+                  <context>parent</context>
+                  <schema/>
+                  <type>attribute</type>
+                  <prefix>NULL</prefix>
+                  <value>authority</value>
+                </create>
+                <read>
+                  <path>mods:genre/@authority</path>
+                  <context>parent</context>
+                </read>
+                <update>
+                  <path>self::node()</path>
+                  <context>self</context>
+                </update>
+                <delete>
+                  <path>self::node()</path>
+                  <context>self</context>
+                </delete>
+              </actions>
+            </properties>
+            <children/>
+          </element>
+        </children>
       </element>
       <element name="originInfo">
         <properties>


### PR DESCRIPTION
**JIRA Ticket**: (https://jira.duraspace.org/browse/ISLANDORA-2382)

# What does this Pull Request do?

Updates the default ingest form to allow submitter to enter their own Genre authority, removing the hard-coded "lctgm" authority attribute.

# What's new?

Turns Genre into a fieldset, with a new Authority field which users can fill out themselves. Should not have any impact on existing practices, except users accustomed to "lctgm" and wanting to use it will have to start entering it when ingesting new collections.

Also updates the form association to use islandora_cleanup_mods_extended.xsl so that empty elements and attributes are removed.

# How should this be tested?

* Ingest a collection in the 7.x branch, review MODS, note authority="lctgm"
* Check out the branch
* Ingest a new Collection using the form. Fill out the Genre and Authority fields as desired. View MODS metadata to make sure it looks right. Default "lctgm" authority should be gone.
* Edit using the form, change Genre and Authority, make sure edits are read and updated properly.
* Edit again, delete data, make sure it's gone.

# Additional notes

In my own custom form I use a select list, which might make things easier on people by giving them a default, but this would restrict options, so I left it a textfield. No default given, but I added some suggestions and the correct authority codes in the field description.

# Interested parties
@Islandora/7-x-1-x-committers
