### PR TITLE
Add hook for sharing and migration function

### DIFF
--- a/includes/utilities.inc
+++ b/includes/utilities.inc
@@ -188,7 +188,7 @@ function islandora_basic_collection_add_to_collection(AbstractObject $new_member
     $new_member->relationships->add(FEDORA_RELS_EXT_URI, 'isMemberOfCollection', $collection->id);
     // Create hook_islandora_basic_collection_share_migrate().
     // Since fake:pid appears everywhere for some reason, do not trigger when this is the object.
-    module_load_include('inc', 'islandora_basic_collection', 'includes/admin.form');
+    module_load_include('inc', 'islandora_basic_collection', 'includes/ingest.form');
     if ($new_member->id != ISLANDORA_BASIC_COLLECTION_FAKE_PID) {
       module_invoke_all('islandora_basic_collection_share_migrate', $new_member, $collection);
     }

--- a/includes/utilities.inc
+++ b/includes/utilities.inc
@@ -183,7 +183,7 @@ function islandora_basic_collection_get_other_parents(AbstractObject $object, Ab
  *   The collection object to add to.
  */
 function islandora_basic_collection_add_to_collection(AbstractObject $new_member, AbstractObject $collection) {
-  // Alerting all modules calling hook_islandora_basic_collection_share_migrate()
+  // Create hook_islandora_basic_collection_share_migrate()
   foreach (module_implements('islandora_basic_collection_share_migrate') as $module) {
     $function = $module . '_islandora_basic_collection_share_migrate';
     $function($new_member, $collection);

--- a/includes/utilities.inc
+++ b/includes/utilities.inc
@@ -183,6 +183,11 @@ function islandora_basic_collection_get_other_parents(AbstractObject $object, Ab
  *   The collection object to add to.
  */
 function islandora_basic_collection_add_to_collection(AbstractObject $new_member, AbstractObject $collection) {
+  // Alerting all modules calling hook_islandora_basic_collection_share_migrate()
+  foreach (module_implements('islandora_basic_collection_share_migrate') as $module) {
+    $function = $module . '_islandora_basic_collection_share_migrate';
+    $function($new_member, $collection);
+  }
   $results = $new_member->relationships->get(FEDORA_RELS_EXT_URI, 'isMemberOfCollection', $collection->id);
   if (empty($results)) {
     $new_member->relationships->add(FEDORA_RELS_EXT_URI, 'isMemberOfCollection', $collection->id);

--- a/includes/utilities.inc
+++ b/includes/utilities.inc
@@ -183,14 +183,14 @@ function islandora_basic_collection_get_other_parents(AbstractObject $object, Ab
  *   The collection object to add to.
  */
 function islandora_basic_collection_add_to_collection(AbstractObject $new_member, AbstractObject $collection) {
-  // Create hook_islandora_basic_collection_share_migrate()
-  foreach (module_implements('islandora_basic_collection_share_migrate') as $module) {
-    $function = $module . '_islandora_basic_collection_share_migrate';
-    $function($new_member, $collection);
-  }
   $results = $new_member->relationships->get(FEDORA_RELS_EXT_URI, 'isMemberOfCollection', $collection->id);
   if (empty($results)) {
     $new_member->relationships->add(FEDORA_RELS_EXT_URI, 'isMemberOfCollection', $collection->id);
+    // Create hook_islandora_basic_collection_share_migrate().
+    // Since fake:pid appears everywhere for some reason, do not trigger when this is the object.
+    if ($new_member->id != "fake:pid") {
+      module_invoke_all('islandora_basic_collection_share_migrate', $new_member, $collection);
+    }
   }
 }
 

--- a/includes/utilities.inc
+++ b/includes/utilities.inc
@@ -188,7 +188,8 @@ function islandora_basic_collection_add_to_collection(AbstractObject $new_member
     $new_member->relationships->add(FEDORA_RELS_EXT_URI, 'isMemberOfCollection', $collection->id);
     // Create hook_islandora_basic_collection_share_migrate().
     // Since fake:pid appears everywhere for some reason, do not trigger when this is the object.
-    if ($new_member->id != "fake:pid") {
+    module_load_include('inc', 'islandora_basic_collection', 'includes/admin.form');
+    if ($new_member->id != ISLANDORA_BASIC_COLLECTION_FAKE_PID) {
       module_invoke_all('islandora_basic_collection_share_migrate', $new_member, $collection);
     }
   }

--- a/islandora_basic_collection.api.php
+++ b/islandora_basic_collection.api.php
@@ -183,3 +183,12 @@ function callback_islandora_basic_collection_query_backends(AbstractObject $obje
   // them.
   return array($total, $pids);
 }
+
+/**
+ * Hook to provide object and collection details when an object is shared or migrated.
+ *
+ * Works only if the migration method uses islandora_basic_collection_add_to_colection().
+ *
+ */ 
+function hook_islandora_basic_collection_share_migrate(AbstractObject $new_member, AbstractObject $collection) {
+}


### PR DESCRIPTION
**JIRA Ticket**: (https://jira.duraspace.org/browse/ISLANDORA-2410)

# What does this Pull Request do?
Creates a new hook, `hook_islandora_basic_collection_share_migrate`, which provides the object being migrated and its new parent to whatever module is calling it.

# What's new?
New hook exists. It can be called.

# How should this be tested?
Enable devel

Call the hook in some other module. For example, in your module "islandora_my_module", add the function:

```
function islandora_my_module_islandora_basic_collection_share_migrate($object, $newparent) {
  dd($object);
  dd($newparent);
}
```

Migrate an object to another collection.

Checking `/tmp/drupal_debug.txt` should show the two parameters have been passed to your function.

# Interested parties
@Islandora/7-x-1-x-committers
