### PR TITLE
ISLANDORA-2382 Bug in original implementation; Flip the defaults around.

### DIFF
--- a/xml/islandora_basic_collection_form_mods.xml
+++ b/xml/islandora_basic_collection_form_mods.xml
@@ -336,7 +336,7 @@ e.g. Creator, Donor, etc.</description>
               <access>TRUE</access>
               <collapsed>FALSE</collapsed>
               <collapsible>FALSE</collapsible>
-              <default_value>lctgm</default_value>
+              <default_value>NULL</default_value>
               <description>A term that best describes the genre of the object. Terms should be taken from a controlled vocabulary such as: &lt;a href="https://www.loc.gov/standards/valuelist/marcgt.html" target="_blank"&gt;MARC Genre Terms (marcgt)&lt;/a&gt;, the &lt;a href="http://www.loc.gov/pictures/collection/tgm/" target="_blank"&gt;Thesaurus for Graphic Materials (lctgm)&lt;/a&gt;, or the &lt;a href="http://www.getty.edu/research/tools/vocabularies/aat/" target="_blank"&gt;Art and Architecture Thesaurus (aat)&lt;/a&gt;.</description>
               <disabled>FALSE</disabled>
               <executes_submit_callback>FALSE</executes_submit_callback>
@@ -376,7 +376,7 @@ e.g. Creator, Donor, etc.</description>
               <access>TRUE</access>
               <collapsed>FALSE</collapsed>
               <collapsible>FALSE</collapsible>
-              <default_value>NULL</default_value>
+              <default_value>lctgm</default_value>
               <description>The authoritative source of your genre term (e.g. marcgt, aat, lctgm).</description>
               <disabled>FALSE</disabled>
               <executes_submit_callback>FALSE</executes_submit_callback>


### PR DESCRIPTION

**JIRA Ticket**: https://jira.duraspace.org/browse/ISLANDORA-2382

See also: https://github.com/Islandora/islandora_solution_pack_collection/pull/213

# What does this Pull Request do?

The original implementation in #213 had the defaults between the genre's content and authority the wrong way around... here, we just correct them.

# What's new?

The value for the authority field should end up in the authority attribute, and the genre content should end up as the text content.

# How should this be tested?

Look at the form, see the defaults in the expected matching elements.

# Additional Notes:

There's a non-zero possibility that users might have ingested reversed content between these two fields, following the provided default... it may be worthwhile to look for a handful of authority names/IDs in the content of genre elements to potentially fix them.

# Interested parties

@bondjimbond @rosiel
