### PR TITLE
ISLANDORA-2458 "Share selected objects" and "Migrate selected objects" buttons should be title case like other buttons.

### DIFF
--- a/includes/manage_collection.inc
+++ b/includes/manage_collection.inc
@@ -456,7 +456,7 @@ function islandora_basic_collection_migrate_children_form(array $form, array &$f
     ),
     'submit' => array(
       '#type' => 'submit',
-      '#value' => t('Migrate selected objects'),
+      '#value' => t('Migrate Selected Objects'),
     ),
     'submit_all' => array(
       '#type' => 'submit',

--- a/includes/manage_collection.inc
+++ b/includes/manage_collection.inc
@@ -376,7 +376,7 @@ function islandora_basic_collection_share_children_form(array $form, array &$for
     ),
     'submit' => array(
       '#type' => 'submit',
-      '#value' => t('Share selected objects'),
+      '#value' => t('Share Selected Objects'),
     ),
     'submit_all' => array(
       '#type' => 'submit',

--- a/tests/islandora_basic_collection_migrate.test
+++ b/tests/islandora_basic_collection_migrate.test
@@ -60,7 +60,7 @@ class IslandoraMigrateCollectionTestCase extends IslandoraCollectionWebTestCase 
       "collection" => $collection_1,
       "children[{$collection_2}]" => TRUE,
     );
-    $this->drupalPost($path, $edit, 'Migrate selected objects', array(), array(), 'islandora-basic-collection-migrate-children-form');
+    $this->drupalPost($path, $edit, 'Migrate Selected Objects', array(), array(), 'islandora-basic-collection-migrate-children-form');
 
     // First, check that Collection 2 shows up in Collection 1.
     $this->drupalGet("islandora/object/{$collection_1}");

--- a/tests/islandora_basic_collection_share.test
+++ b/tests/islandora_basic_collection_share.test
@@ -67,7 +67,7 @@ class IslandoraShareCollectionTestCase extends IslandoraCollectionWebTestCase {
       "collection" => $collection_1,
       "children[{$collection_2}]" => TRUE,
     );
-    $this->drupalPost($path, $edit, 'Share selected objects', array(), array(), 'islandora-basic-collection-share-children-form');
+    $this->drupalPost($path, $edit, 'Share Selected Objects', array(), array(), 'islandora-basic-collection-share-children-form');
 
     // First, check that Collection 2 shows up in Collection 1.
     $this->drupalGet("islandora/object/{$collection_1}");


### PR DESCRIPTION
**JIRA Ticket**: https://jira.duraspace.org/browse/ISLANDORA-2458

# What does this Pull Request do?

This is a super trivial update to make the migrate and share buttons consistently title case, because the inconsistency bugged me while writing docs for these functions. 

# What's new?

Capitalized the words "Selected Objects" on two different buttons.


# How should this be tested?

I think you should just be able to pull this in and go look at the buttons under Mange -> Collection -> "Share members" and "Migrate members" and verify that the buttons are all title case.

# Additional Notes:

* Does this change the interface, add a new feature, or otherwise change behaviours that would require updating documentation? I'm literally writing the How-To documentation for this function right now, so I'd do new screenshots if this goes in.

# Interested parties
@willtp87 as Maintainer or @DonRichards for docs.
