### PR TITLE
Fix missing MODS entry in CModel definition

### DIFF
--- a/xml/islandora_basic_collection_ds_composite_model.xml
+++ b/xml/islandora_basic_collection_ds_composite_model.xml
@@ -1,6 +1,9 @@
 <?xml version="1.0"?>
 <dsCompositeModel xmlns="info:fedora/fedora-system:def/dsCompositeModel#">
   <!-- using this as a guide -->
+  <dsTypeModel ID="MODS" optional="true">
+    <form FORMAT_URI="http://www.loc.gov/mods/v3" MIME="application/xml"/>
+  </dsTypeModel>
   <dsTypeModel ID="DC">
     <form FORMAT_URI="http://www.openarchives.org/OAI/2.0/oai_dc/" MIME="application/xml"/>
   </dsTypeModel>


### PR DESCRIPTION
**JIRA Ticket**: (https://jira.lyrasis.org/browse/ISLANDORA-2510)

Discovered at https://github.com/mnylc/islandora_multi_importer/pull/117#issuecomment-634215264

# What does this Pull Request do?

Adds a MODS datastream to the content model definition. As with other CModels, it leaves MODS optional.

# What's new?

For some reason, the Collection content model did not have MODS defined as part of it, despite MODS being integrated into it the same as any other content model. Islandora Batch fails if you don't have a MODS datastream, so logically it should be part of the definition anyway.

This PR addresses that, and allows other modules to understand that Collection objects could (really should) have a MODS datastream.

# How should this be tested?

* Check out this branch, then reinstall the Collection CModel (Islandora -> Solution Pack Config -> Solution Packs Required Objects)
* Create some Collections normally, make sure nothing is broken.
* Try this IMI pull request: https://github.com/mnylc/islandora_multi_importer/pull/117
  * Use a CSV of Collection objects - https://github.com/mnylc/islandora_multi_importer/files/4652353/npc_imi.copy.txt 
* On the CModel Mapping tab, see whether a mapping for MODS is provided. (Without this PR, it is not.)
* Ingest it - your collections should be successfully processed.

# Additional Notes:
* Should not impact any existing code.

# Interested parties
@DiegoPino 
@Islandora/7-x-1-x-committers 