### PR TITLE
Adding note to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ This module requires the following modules/libraries:
 
 **NOTE**: The collection solution pack either requires that the [resource index](https://wiki.duraspace.org/display/FEDORA37/Resource+Index) is enabled in Fedora or you have the [Islandora Solr](https://github.com/islandora/islandora_solr_search) module installed to perform its queries.
 
-**NOTE**: After enabling the display of object metadata, it is possible that some metadata (e.g Description) will not display if the [Islandora Context](https://github.com/SFULibrary/islandora_context) module is not enabled.
+**NOTE**: After enabling the display of object metadata, it is possible that some metadata (e.g. Description) will not display if the [Islandora Context](https://github.com/SFULibrary/islandora_context) module is not enabled.
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ This module requires the following modules/libraries:
 
 **NOTE**: The collection solution pack either requires that the [resource index](https://wiki.duraspace.org/display/FEDORA37/Resource+Index) is enabled in Fedora or you have the [Islandora Solr](https://github.com/islandora/islandora_solr_search) module installed to perform its queries.
 
+**NOTE**: After enabling the display of object metadata, it is possible that some metadata (e.g Description) will not display if the [Islandora Context](https://github.com/SFULibrary/islandora_context) module is not enabled.
+
 ## Installation
 
 Install as usual, see [this](https://drupal.org/documentation/install/modules-themes/modules-7) for further information.


### PR DESCRIPTION
No changes to the code; it is possible for some metadata to not be shown when they should be. Enabling the "Islandora Context" module somehow fixes this, a note has been added to the README reflecting this.