### PR TITLE
Solr version of Collection Object Count

### DIFF
--- a/includes/blocks.inc
+++ b/includes/blocks.inc
@@ -74,12 +74,16 @@ function islandora_basic_collection_clear_object_count_cache() {
  * Outputs a JSON string to the buffer.
  */
 function islandora_basic_collection_object_count_callback() {
+  $count_method = variable_get('islandora_basic_collection_count_method', 'SPARQL');
+
+
   $cid = islandora_basic_collection_get_object_count_block_cache_id();
 
   if ($value = cache_get($cid, 'cache')) {
     $substitutions = $value->data;
   }
   else {
+
     $tuque = islandora_get_tuque_connection();
     $objects_query_array = islandora_basic_collection_get_query_info(array(
       'object' => islandora_object_load(variable_get('islandora_repository_pid', 'islandora:root')),
@@ -87,10 +91,71 @@ function islandora_basic_collection_object_count_callback() {
       'all_objects' => TRUE,
     ));
     $collection_query_array = islandora_basic_collection_get_query_info(array(
-      'object' => islandora_object_load(variable_get('islandora_repository_pid', 'islandora:root')),
-      'collection_listing' => TRUE,
-      'all_objects' => FALSE,
-    ));
+    'object' => islandora_object_load(variable_get('islandora_repository_pid', 'islandora:root')),
+    'collection_listing' => TRUE,
+    'all_objects' => FALSE,
+  ));
+
+
+  // Setup Solr query for collection and object counts.
+  if ($count_method == "Solr") {
+    $all_cmodels = islandora_get_content_models();
+    $models_to_exclude = variable_get('islandora_basic_collection_object_count_listing_content_models_to_restrict', FALSE);
+    $cmodels_to_count = array();
+    foreach($all_cmodels AS $cmodel) {
+      if ($models_to_exclude[$cmodel['pid']] != '0') {
+        $cmodels_to_count[] = $cmodel['pid'];
+      }
+    }
+
+    // Collection count Solr query.
+    $collection_query = "RELS_EXT_hasModel_uri_mt:collection";
+    $qp = new IslandoraSolrQueryProcessor();
+    $qp->buildQuery($collection_query);
+    $qp->solrParams['fl'] = "PID";
+    $qp->solrLimit = 10000000;
+    $qp->executeQuery(FALSE);
+    try {
+      $results = $qp->islandoraSolrResult['response']['numFound'];
+    }
+    catch (Exception $e) {
+      watchdog_exception('Islandora Basic Collection', $e, 'Got an exception searching counting Collections.', array(), WATCHDOG_ERROR);
+      $results = array();
+    }
+    $collection_count = $results;
+    // Solr query for object count.
+    $object_query = "";
+    $i = 0;
+    foreach ($cmodels_to_count AS $model) {
+      if ($i == 0) {
+        $object_query = 'RELS_EXT_hasModel_uri_mt:"' . $model . '"';
+      }
+      else {
+        $object_query = $object_query . ' OR RELS_EXT_hasModel_uri_mt:"' . $model . '"';
+      }
+      $i++;
+    }
+
+    $qp = new IslandoraSolrQueryProcessor();
+    $qp->buildQuery($object_query);
+    $qp->solrParams['fl'] = "PID";
+    $qp->solrLimit = 10000000;
+    $qp->executeQuery(FALSE);
+    try {
+      $results = $qp->islandoraSolrResult['response']['numFound'];
+    }
+    catch (Exception $e) {
+      watchdog_exception('Islandora Basic Collection', $e, 'Got an exception searching counting Objects.', array(), WATCHDOG_ERROR);
+      $results = array();
+    }
+    $object_count = $results;
+
+    $total_collection_count = $collection_count;
+    $total_object_count = $object_count;
+  }
+
+  else if ($count_method == "SPARQL") {
+
     $collection_objects = $tuque->repository->ri->sparqlQuery($collection_query_array['query'], $collection_query_array['type']);
     $total_object_count = $tuque->repository->ri->countQuery($objects_query_array['query'], $objects_query_array['type']);
 
@@ -103,6 +168,8 @@ function islandora_basic_collection_object_count_callback() {
       $collections = islandora_basic_collection_filter_collection_by_cmodel($collections, array_filter($models_to_exclude));
     }
     $total_collection_count = count($collections);
+
+  }
 
     $substitutions = array(
       '!objects' => $total_object_count,

--- a/includes/blocks.inc
+++ b/includes/blocks.inc
@@ -109,7 +109,7 @@ function islandora_basic_collection_object_count_callback() {
     }
 
     // Collection count Solr query.
-    $collection_query = "RELS_EXT_hasModel_uri_mt:collection";
+    $collection_query = 'RELS_EXT_hasModel_uri_s:"info:fedora/islandora:collectionCModel"';
     $qp = new IslandoraSolrQueryProcessor();
     $qp->buildQuery($collection_query);
     $qp->solrParams['fl'] = "PID";
@@ -128,10 +128,10 @@ function islandora_basic_collection_object_count_callback() {
     $i = 0;
     foreach ($cmodels_to_count AS $model) {
       if ($i == 0) {
-        $object_query = 'RELS_EXT_hasModel_uri_mt:"' . $model . '"';
+        $object_query = 'RELS_EXT_hasModel_uri_ms:"info:fedora/' . $model . '"';
       }
       else {
-        $object_query = $object_query . ' OR RELS_EXT_hasModel_uri_mt:"' . $model . '"';
+        $object_query = $object_query . ' OR RELS_EXT_hasModel_uri_ms:"info:fedora/' . $model . '"';
       }
       $i++;
     }

--- a/includes/blocks.inc
+++ b/includes/blocks.inc
@@ -99,6 +99,9 @@ function islandora_basic_collection_object_count_callback() {
 
   // Setup Solr query for collection and object counts.
   if ($count_method == "Solr") {
+    module_load_include('islandora_solr_search', 'inc', 'admin');
+    $cmodel_field = variable_get('islandora_solr_content_model_field', 'RELS_EXT_hasModel_uri_ms');
+
     $all_cmodels = islandora_get_content_models();
     $models_to_exclude = variable_get('islandora_basic_collection_object_count_listing_content_models_to_restrict', FALSE);
     $cmodels_to_count = array();
@@ -109,7 +112,7 @@ function islandora_basic_collection_object_count_callback() {
     }
 
     // Collection count Solr query.
-    $collection_query = 'RELS_EXT_hasModel_uri_s:"info:fedora/islandora:collectionCModel"';
+    $collection_query = $cmodel_field . ':"info:fedora/islandora:collectionCModel"';
     $qp = new IslandoraSolrQueryProcessor();
     $qp->buildQuery($collection_query);
     $qp->solrParams['fl'] = "PID";
@@ -128,10 +131,10 @@ function islandora_basic_collection_object_count_callback() {
     $i = 0;
     foreach ($cmodels_to_count AS $model) {
       if ($i == 0) {
-        $object_query = 'RELS_EXT_hasModel_uri_ms:"info:fedora/' . $model . '"';
+        $object_query = $cmodel_field . ':"info:fedora/' . $model . '"';
       }
       else {
-        $object_query = $object_query . ' OR RELS_EXT_hasModel_uri_ms:"info:fedora/' . $model . '"';
+        $object_query = $object_query . ' OR ' . $cmodel_field . ':"info:fedora/' . $model . '"';
       }
       $i++;
     }

--- a/includes/blocks.inc
+++ b/includes/blocks.inc
@@ -98,8 +98,7 @@ function islandora_basic_collection_object_count_callback() {
 
 
   // Setup Solr query for collection and object counts.
-  if ($count_method == "Solr") {
-    module_load_include('islandora_solr_search', 'inc', 'admin');
+  if ($count_method == "Solr" && module_exists('islandora_solr')) {
     $cmodel_field = variable_get('islandora_solr_content_model_field', 'RELS_EXT_hasModel_uri_ms');
 
     $all_cmodels = islandora_get_content_models();

--- a/includes/blocks.inc
+++ b/includes/blocks.inc
@@ -156,8 +156,7 @@ function islandora_basic_collection_object_count_callback() {
     $total_object_count = $object_count;
   }
 
-  else if ($count_method == "SPARQL") {
-
+  else {
     $collection_objects = $tuque->repository->ri->sparqlQuery($collection_query_array['query'], $collection_query_array['type']);
     $total_object_count = $tuque->repository->ri->countQuery($objects_query_array['query'], $objects_query_array['type']);
 

--- a/includes/blocks.inc
+++ b/includes/blocks.inc
@@ -121,7 +121,7 @@ function islandora_basic_collection_object_count_callback() {
       $results = $qp->islandoraSolrResult['response']['numFound'];
     }
     catch (Exception $e) {
-      watchdog_exception('Islandora Basic Collection', $e, 'Got an exception searching counting Collections.', array(), WATCHDOG_ERROR);
+      watchdog_exception('Islandora Basic Collection', $e, 'Got an exception counting Collections.', array(), WATCHDOG_ERROR);
       $results = array();
     }
     $collection_count = $results;
@@ -147,7 +147,7 @@ function islandora_basic_collection_object_count_callback() {
       $results = $qp->islandoraSolrResult['response']['numFound'];
     }
     catch (Exception $e) {
-      watchdog_exception('Islandora Basic Collection', $e, 'Got an exception searching counting Objects.', array(), WATCHDOG_ERROR);
+      watchdog_exception('Islandora Basic Collection', $e, 'Got an exception counting Objects.', array(), WATCHDOG_ERROR);
       $results = array();
     }
     $object_count = $results;

--- a/includes/blocks.inc
+++ b/includes/blocks.inc
@@ -113,7 +113,7 @@ function islandora_basic_collection_object_count_callback() {
     $qp = new IslandoraSolrQueryProcessor();
     $qp->buildQuery($collection_query);
     $qp->solrParams['fl'] = "PID";
-    $qp->solrLimit = 10000000;
+    $qp->solrLimit = -1;
     $qp->executeQuery(FALSE);
     try {
       $results = $qp->islandoraSolrResult['response']['numFound'];
@@ -139,7 +139,7 @@ function islandora_basic_collection_object_count_callback() {
     $qp = new IslandoraSolrQueryProcessor();
     $qp->buildQuery($object_query);
     $qp->solrParams['fl'] = "PID";
-    $qp->solrLimit = 10000000;
+    $qp->solrLimit = -1;
     $qp->executeQuery(FALSE);
     try {
       $results = $qp->islandoraSolrResult['response']['numFound'];

--- a/includes/blocks.inc
+++ b/includes/blocks.inc
@@ -104,7 +104,7 @@ function islandora_basic_collection_object_count_callback() {
     $all_cmodels = islandora_get_content_models();
     $models_to_exclude = variable_get('islandora_basic_collection_object_count_listing_content_models_to_restrict', FALSE);
     $cmodels_to_count = array();
-    foreach($all_cmodels AS $cmodel) {
+    foreach ($all_cmodels AS $cmodel) {
       if ($models_to_exclude[$cmodel['pid']] != '0') {
         $cmodels_to_count[] = $cmodel['pid'];
       }

--- a/islandora_basic_collection.install
+++ b/islandora_basic_collection.install
@@ -35,6 +35,7 @@ function islandora_basic_collection_uninstall() {
     'islandora_basic_collection_display_backend',
     'islandora_basic_collection_disable_display_generation',
     'islandora_basic_collection_admin_page_size',
+    'islandora_basic_collection_count_method',
   );
   array_walk($variables, 'variable_del');
 }

--- a/islandora_basic_collection.module
+++ b/islandora_basic_collection.module
@@ -1019,7 +1019,7 @@ function islandora_basic_collection_block_configure($delta = '') {
         'Solr' => t('Solr'),
       ),
       '#default_value' => variable_get('islandora_basic_collection_count_method', 'SPARQL'),
-      '#description' => t('Select method for querying the number of objects and collections. Solr is recommended for larger repositories.'),
+      '#description' => t('Select method for querying the number of objects and collections. Solr is recommended for larger repositories. Respects XACML'),
     );
 
     module_load_include('inc', 'islandora', 'includes/utilities');

--- a/islandora_basic_collection.module
+++ b/islandora_basic_collection.module
@@ -999,6 +999,17 @@ function islandora_basic_collection_block_info() {
  */
 function islandora_basic_collection_block_configure($delta = '') {
   if ($delta == 'collection_object_count') {
+    if (module_exists('islandora_solr')) {
+      $count_method_options = array(
+        'SPARQL' => t('SPARQL'),
+        'Solr' => t('Solr'),
+      );
+    }
+    else {
+      $count_method_options = array(
+        'SPARQL' => t('SPARQL'),
+      );
+    }
     $block['islandora_basic_collection_title_phrase'] = array(
       '#type' => 'textfield',
       '#title' => t('The sentence to appear to describe the number of objects and collections present.'),

--- a/islandora_basic_collection.module
+++ b/islandora_basic_collection.module
@@ -1011,6 +1011,17 @@ function islandora_basic_collection_block_configure($delta = '') {
       '#description' => t('Placeholder to output, to be replaced by phrase populated by AJAX.'),
       '#default_value' => variable_get('islandora_basic_collection_object_count_listing_placeholder', 'Counting items in collections...'),
     );
+    $block['islandora_basic_collection_count_method'] = array(
+      '#type' => 'select',
+      '#title' => 'Collection count query method',
+      '#options' => array(
+        'SPARQL' => t('SPARQL'),
+        'Solr' => t('Solr'),
+      ),
+      '#default_value' => variable_get('islandora_basic_collection_count_method', 'SPARQL'),
+      '#description' => t('Select method for querying the number of objects and collections. Solr is recommended for larger repositories.'),
+    );
+
     module_load_include('inc', 'islandora', 'includes/utilities');
     $formatted_models = array();
     $models = islandora_get_content_models();
@@ -1092,6 +1103,7 @@ function islandora_basic_collection_block_save($delta = '', $edit = array()) {
     variable_set('islandora_basic_collection_object_count_listing_content_models_to_restrict', $edit['content_models']);
     variable_set('islandora_basic_collection_object_count_listing_phrase', $edit['islandora_basic_collection_title_phrase']);
     variable_set('islandora_basic_collection_object_count_listing_placeholder', $edit['islandora_basic_collection_title_placeholder']);
+    variable_set('islandora_basic_collection_count_method', $edit['islandora_basic_collection_count_method']);
   }
   if ($delta == 'collection_listing') {
     variable_set('islandora_basic_collection_listing_block_links_to_render', $edit['islandora_basic_collection_links_to_render']);

--- a/islandora_basic_collection.module
+++ b/islandora_basic_collection.module
@@ -1030,7 +1030,7 @@ function islandora_basic_collection_block_configure($delta = '') {
         'Solr' => t('Solr'),
       ),
       '#default_value' => variable_get('islandora_basic_collection_count_method', 'SPARQL'),
-      '#description' => t('Select method for querying the number of objects and collections. Solr is recommended for larger repositories. Respects XACML'),
+      '#description' => t('Select method for querying the number of objects and collections. Solr is recommended for larger repositories. Respects XACML.'),
     );
 
     module_load_include('inc', 'islandora', 'includes/utilities');

--- a/xml/islandora_basic_collection_ds_composite_model.xml
+++ b/xml/islandora_basic_collection_ds_composite_model.xml
@@ -1,6 +1,9 @@
 <?xml version="1.0"?>
 <dsCompositeModel xmlns="info:fedora/fedora-system:def/dsCompositeModel#">
   <!-- using this as a guide -->
+  <dsTypeModel ID="MODS" optional="true">
+    <form FORMAT_URI="http://www.loc.gov/mods/v3" MIME="application/xml"/>
+  </dsTypeModel>
   <dsTypeModel ID="DC">
     <form FORMAT_URI="http://www.openarchives.org/OAI/2.0/oai_dc/" MIME="application/xml"/>
   </dsTypeModel>


### PR DESCRIPTION
**JIRA Ticket**: (https://jira.lyrasis.org/browse/ISLANDORA-2519)

# What does this Pull Request do?

Creates a Solr option on the Collection Object Count block, which produces a count of objects and collections from the Solr index instead of the Resource Index.

# What's new?
* Adds a new config option to the block (Solr or SPARQL)
* SPARQL remains default
* Solr version queries the Solr index and produces a much faster result.

# How should this be tested?

* Enable the block on a page and review the result
* Configure the block to use Solr and review the result
* Un-check a few CModels and verify that the count has reduced
* Note that you will need to flush caches each time you make a change, as this block gets cached

# Additional Notes:
The SPARQL version of this block adjusts the number of collections it reports based on the CModels contained in the collections -- if a collection contains only objects in the exclusions list, then it is not counted. In the Solr version, this elimination is not done -- from my perspective the adjustment is not necessarily expected behaviour, and it's a lot easier not to bother with it. Am open to arguments against this position.

# Interested parties
@Islandora/7-x-1-x-committers
